### PR TITLE
feat: NBT-103 댓글 등록 기능 구현

### DIFF
--- a/src/main/java/com/newbit/post/controller/CommentController.java
+++ b/src/main/java/com/newbit/post/controller/CommentController.java
@@ -1,0 +1,28 @@
+package com.newbit.post.controller;
+
+import com.newbit.post.dto.request.CommentCreateRequest;
+import com.newbit.post.dto.response.CommentResponse;
+import com.newbit.post.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts/{postId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    @Operation(summary = "댓글 등록", description = "게시글에 댓글을 등록합니다.")
+    public ResponseEntity<CommentResponse> createComment(
+            @PathVariable Long postId,
+            @RequestBody @Valid CommentCreateRequest request
+    ) {
+        CommentResponse response = commentService.createComment(postId, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/newbit/post/controller/PostController.java
+++ b/src/main/java/com/newbit/post/controller/PostController.java
@@ -9,10 +9,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "게시글 API", description = "게시글 등록, 수정, 삭제 관련")
+@Tag(name = "게시글 API", description = "게시글 등록, 수정, 삭제, 조회 관련")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
@@ -46,5 +49,13 @@ public class PostController {
     public ResponseEntity<Void> deletePost(@PathVariable Long id) {
         postService.deletePost(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 조회", description = "페이징 정보를 기반으로 게시글 목록을 조회합니다.")
+    public ResponseEntity<Page<PostResponse>> getPostList(
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        Page<PostResponse> responses = postService.getPostList(pageable);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/newbit/post/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/newbit/post/dto/request/CommentCreateRequest.java
@@ -1,0 +1,22 @@
+package com.newbit.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateRequest {
+
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private Long postId;
+}

--- a/src/main/java/com/newbit/post/dto/response/CommentResponse.java
+++ b/src/main/java/com/newbit/post/dto/response/CommentResponse.java
@@ -1,0 +1,28 @@
+package com.newbit.post.dto.response;
+
+import com.newbit.post.entity.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentResponse {
+
+    private final Long id;
+    private final String content;
+    private final int reportCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final Long userId;
+    private final Long postId;
+
+    public CommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.reportCount = comment.getReportCount();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+        this.userId = comment.getUserId();
+        this.postId = comment.getPost().getId();
+    }
+}

--- a/src/main/java/com/newbit/post/entity/Comment.java
+++ b/src/main/java/com/newbit/post/entity/Comment.java
@@ -1,0 +1,58 @@
+package com.newbit.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(name = "report_count", nullable = false)
+    private int reportCount = 0;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/newbit/post/repository/CommentRepository.java
+++ b/src/main/java/com/newbit/post/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.newbit.post.repository;
+
+import com.newbit.post.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/newbit/post/service/CommentService.java
+++ b/src/main/java/com/newbit/post/service/CommentService.java
@@ -1,0 +1,36 @@
+package com.newbit.post.service;
+
+import com.newbit.post.dto.request.CommentCreateRequest;
+import com.newbit.post.dto.response.CommentResponse;
+import com.newbit.post.entity.Comment;
+import com.newbit.post.entity.Post;
+import com.newbit.post.repository.CommentRepository;
+import com.newbit.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long postId, CommentCreateRequest request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .userId(request.getUserId())
+                .reportCount(0)
+                .post(post)
+                .build();
+
+        commentRepository.save(comment);
+        return new CommentResponse(comment);
+    }
+
+}

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -6,8 +6,13 @@ import com.newbit.post.dto.response.PostResponse;
 import com.newbit.post.entity.Post;
 import com.newbit.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +49,12 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
         post.softDelete();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostResponse> getPostList(Pageable pageable) {
+        Page<Post> postPage = postRepository.findAll(pageable);
+        return postRepository.findAll(pageable)
+                .map(PostResponse::new);
     }
 }

--- a/src/test/java/com/newbit/post/service/CommentServiceTest.java
+++ b/src/test/java/com/newbit/post/service/CommentServiceTest.java
@@ -1,0 +1,61 @@
+package com.newbit.post.service;
+
+import com.newbit.post.dto.request.CommentCreateRequest;
+import com.newbit.post.dto.response.CommentResponse;
+import com.newbit.post.entity.Comment;
+import com.newbit.post.entity.Post;
+import com.newbit.post.repository.CommentRepository;
+import com.newbit.post.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CommentServiceTest {
+
+    private CommentRepository commentRepository;
+    private PostRepository postRepository;
+    private CommentService commentService;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        postRepository = mock(PostRepository.class); // ← 추가
+
+        commentService = new CommentService(commentRepository, postRepository); // ← 수정
+    }
+
+    @Test
+    void 댓글_등록_성공() {
+        // given
+        Long postId = 10L;
+
+        CommentCreateRequest request = CommentCreateRequest.builder()
+                .content("댓글 내용입니다.")
+                .userId(1L)
+                .postId(postId)
+                .build();
+
+        Post mockPost = Post.builder()
+                .id(postId)
+                .title("제목")
+                .content("내용")
+                .userId(1L)
+                .postCategoryId(2L)
+                .build();
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+        when(commentRepository.save(any(Comment.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        CommentResponse response = commentService.createComment(postId, request);
+
+        // then
+        assertThat(response.getContent()).isEqualTo("댓글 내용입니다.");
+        verify(commentRepository, times(1)).save(any(Comment.class));
+    }
+}

--- a/src/test/java/com/newbit/post/service/PostServiceTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceTest.java
@@ -6,7 +6,10 @@ import com.newbit.post.entity.Post;
 import com.newbit.post.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -113,5 +116,43 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.deletePost(postId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 게시글이 존재하지 않습니다.");
+    }
+
+    @Test
+    void 게시글_목록_조회_성공() {
+        // given
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt").descending());
+        List<Post> postList = List.of(
+                Post.builder()
+                        .id(1L)
+                        .title("제목1")
+                        .content("내용1")
+                        .userId(1L)
+                        .postCategoryId(1L)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build(),
+                Post.builder()
+                        .id(2L)
+                        .title("제목2")
+                        .content("내용2")
+                        .userId(2L)
+                        .postCategoryId(1L)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build()
+        );
+
+        Page<Post> postPage = new PageImpl<>(postList, pageable, postList.size());
+
+        when(postRepository.findAll(pageable)).thenReturn(postPage);
+
+        // when
+        var result = postService.getPostList(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("제목1");
+        verify(postRepository, times(1)).findAll(pageable);
     }
 }


### PR DESCRIPTION
### 🛰️ Issue
close #91 

### 🪐 작업 내용
게시글에 댓글을 등록할 수 있는 기능 구현
댓글 등록 요청을 처리하는 CommentService.createComment() 메서드 추가
댓글 등록 요청을 위한 DTO CommentCreateRequest 생성
댓글 등록 결과를 반환하는 DTO CommentResponse 생성
댓글 엔티티(Comment) 생성 및 Post와 연관관계 설정
댓글 등록 단위 테스트 코드 작성 (CommentServiceTest)
댓글 등록 시 게시글 존재 여부 확인 및 예외 처리

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] swagger
- [x] 단위테스트
