### PR TITLE
Nbt 156 공개 칼럼 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/newbit/column/controller/ColumnController.java
+++ b/src/main/java/com/newbit/column/controller/ColumnController.java
@@ -1,15 +1,14 @@
 package com.newbit.column.controller;
 
 import com.newbit.column.dto.response.GetColumnDetailResponseDto;
+import com.newbit.column.dto.response.GetColumnListResponseDto;
 import com.newbit.column.service.ColumnService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/columns")
@@ -27,4 +26,14 @@ public class ColumnController {
     ) {
         return columnService.getColumnDetail(userId, columnId);
     }
+
+    @GetMapping("/public-list")
+    @Operation(summary = "공개된 칼럼 목록 조회 (페이징)", description = "공개된 모든 칼럼을 페이지별로 조회합니다.")
+    public Page<GetColumnListResponseDto> getPublicColumnList(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
+    ) {
+        return columnService.getPublicColumnList(page, size);
+    }
+
 }

--- a/src/main/java/com/newbit/column/domain/Column.java
+++ b/src/main/java/com/newbit/column/domain/Column.java
@@ -39,8 +39,6 @@ public class Column {
 
     private String thumbnailUrl;
 
-    private Long mentorId;
-
     @CreatedDate
     @jakarta.persistence.Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/newbit/column/domain/Column.java
+++ b/src/main/java/com/newbit/column/domain/Column.java
@@ -2,7 +2,10 @@ package com.newbit.column.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +40,22 @@ public class Column {
 
     private Long mentorId;
 
+    @CreatedDate
+    @jakarta.persistence.Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @jakarta.persistence.Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @jakarta.persistence.Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @OneToMany(mappedBy = "column", cascade = CascadeType.ALL)
     @Builder.Default
     private List<ColumnRequest> requests = new ArrayList<>();
+
+    public void markAsDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/newbit/column/domain/Column.java
+++ b/src/main/java/com/newbit/column/domain/Column.java
@@ -1,5 +1,6 @@
 package com.newbit.column.domain;
 
+import com.newbit.user.entity.Mentor;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -54,6 +55,11 @@ public class Column {
     @OneToMany(mappedBy = "column", cascade = CascadeType.ALL)
     @Builder.Default
     private List<ColumnRequest> requests = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "mentor_id")
+    private Mentor mentor;
+
 
     public void markAsDeleted() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/newbit/column/dto/response/GetColumnDetailResponseDto.java
+++ b/src/main/java/com/newbit/column/dto/response/GetColumnDetailResponseDto.java
@@ -29,4 +29,19 @@ public class GetColumnDetailResponseDto {
 
     @Schema(description = "멘토 ID", example = "3")
     private Long mentorId;
+
+    @Schema(description = "멘토 닉네임", example = "개발자도토리")
+    private String mentorNickname;
+
+    public GetColumnDetailResponseDto(Long columnId, String title, String content, Integer price,
+                                      String thumbnailUrl, int likeCount, Long mentorId, String mentorNickname) {
+        this.columnId = columnId;
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.thumbnailUrl = thumbnailUrl;
+        this.likeCount = likeCount;
+        this.mentorId = mentorId;
+        this.mentorNickname = mentorNickname;
+    }
 }

--- a/src/main/java/com/newbit/column/dto/response/GetColumnListResponseDto.java
+++ b/src/main/java/com/newbit/column/dto/response/GetColumnListResponseDto.java
@@ -1,11 +1,9 @@
 package com.newbit.column.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class GetColumnListResponseDto {
 
     @Schema(description = "칼럼 ID", example = "1")
@@ -25,5 +23,21 @@ public class GetColumnListResponseDto {
 
     @Schema(description = "멘토 ID", example = "5")
     private Long mentorId;
+
+    @Schema(description = "멘토 닉네임", example = "개발자도토리")
+    private String mentorNickname;
+
+    public GetColumnListResponseDto(Long columnId, String title, String thumbnailUrl,
+                                    Integer price, Integer likeCount,
+                                    Long mentorId, String mentorNickname) {
+        this.columnId = columnId;
+        this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
+        this.price = price;
+        this.likeCount = likeCount;
+        this.mentorId = mentorId;
+        this.mentorNickname = mentorNickname;
+    }
+
 }
 

--- a/src/main/java/com/newbit/column/dto/response/GetColumnListResponseDto.java
+++ b/src/main/java/com/newbit/column/dto/response/GetColumnListResponseDto.java
@@ -1,9 +1,12 @@
 package com.newbit.column.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@Schema(description = "공개 칼럼 리스트 조회 응답")
 public class GetColumnListResponseDto {
 
     @Schema(description = "칼럼 ID", example = "1")

--- a/src/main/java/com/newbit/column/dto/response/GetColumnListResponseDto.java
+++ b/src/main/java/com/newbit/column/dto/response/GetColumnListResponseDto.java
@@ -1,0 +1,29 @@
+package com.newbit.column.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetColumnListResponseDto {
+
+    @Schema(description = "칼럼 ID", example = "1")
+    private Long columnId;
+
+    @Schema(description = "제목", example = "이직을 위한 포트폴리오 전략")
+    private String title;
+
+    @Schema(description = "썸네일 URL", example = "https://example.com/image.jpg")
+    private String thumbnailUrl;
+
+    @Schema(description = "가격", example = "1000")
+    private Integer price;
+
+    @Schema(description = "좋아요 수", example = "12")
+    private Integer likeCount;
+
+    @Schema(description = "멘토 ID", example = "5")
+    private Long mentorId;
+}
+

--- a/src/main/java/com/newbit/column/mapper/ColumnMapper.java
+++ b/src/main/java/com/newbit/column/mapper/ColumnMapper.java
@@ -4,18 +4,19 @@ import com.newbit.column.dto.request.CreateColumnRequestDto;
 import com.newbit.column.domain.Column;
 import com.newbit.column.domain.ColumnRequest;
 import com.newbit.column.enums.RequestType;
+import com.newbit.user.entity.Mentor;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ColumnMapper {
 
-    public Column toColumn(CreateColumnRequestDto dto, Long mentorId) {
+    public Column toColumn(CreateColumnRequestDto dto, Mentor mentor) {
         return Column.builder()
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .price(dto.getPrice())
                 .thumbnailUrl(dto.getThumbnailUrl())
-                .mentorId(mentorId)
+                .mentor(mentor)
                 .isPublic(false)
                 .likeCount(0)
                 .build();

--- a/src/main/java/com/newbit/column/repository/ColumnRepository.java
+++ b/src/main/java/com/newbit/column/repository/ColumnRepository.java
@@ -1,10 +1,21 @@
 package com.newbit.column.repository;
 
 import com.newbit.column.domain.Column;
+import com.newbit.column.dto.response.GetColumnListResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ColumnRepository extends JpaRepository<Column, Long> {
-    Page<Column> findAllByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("SELECT new com.newbit.column.dto.response.GetColumnListResponseDto( " +
+            "c.columnId, c.title, c.thumbnailUrl, c.price, c.likeCount, m.mentorId, u.nickname) " +
+            "FROM Column c " +
+            "JOIN c.mentor m " +
+            "JOIN m.user u " +
+            "WHERE c.isPublic = true " +
+            "ORDER BY c.createdAt DESC")
+
+    Page<GetColumnListResponseDto> findAllByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/newbit/column/repository/ColumnRepository.java
+++ b/src/main/java/com/newbit/column/repository/ColumnRepository.java
@@ -1,11 +1,15 @@
 package com.newbit.column.repository;
 
 import com.newbit.column.domain.Column;
+import com.newbit.column.dto.response.GetColumnDetailResponseDto;
 import com.newbit.column.dto.response.GetColumnListResponseDto;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ColumnRepository extends JpaRepository<Column, Long> {
 
@@ -18,4 +22,13 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
             "ORDER BY c.createdAt DESC")
 
     Page<GetColumnListResponseDto> findAllByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("SELECT new com.newbit.column.dto.response.GetColumnDetailResponseDto( " +
+            "c.columnId, c.title, c.content, c.price, c.thumbnailUrl, c.likeCount, m.mentorId, u.nickname) " +
+            "FROM Column c " +
+            "JOIN c.mentor m " +
+            "JOIN m.user u " +
+            "WHERE c.columnId = :columnId AND c.isPublic = true")
+    Optional<GetColumnDetailResponseDto> findPublicColumnDetailById(@Param("columnId") Long columnId);
+
 }

--- a/src/main/java/com/newbit/column/repository/ColumnRepository.java
+++ b/src/main/java/com/newbit/column/repository/ColumnRepository.java
@@ -1,6 +1,10 @@
 package com.newbit.column.repository;
 
 import com.newbit.column.domain.Column;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ColumnRepository extends JpaRepository<Column, Long> {}
+public interface ColumnRepository extends JpaRepository<Column, Long> {
+    Page<Column> findAllByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/newbit/column/service/ColumnRequestService.java
+++ b/src/main/java/com/newbit/column/service/ColumnRequestService.java
@@ -14,6 +14,8 @@ import com.newbit.column.repository.ColumnRepository;
 import com.newbit.column.repository.ColumnRequestRepository;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.user.entity.Mentor;
+import com.newbit.user.repository.MentorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,11 +25,16 @@ public class ColumnRequestService {
 
     private final ColumnRepository columnRepository;
     private final ColumnRequestRepository columnRequestRepository;
+    private final MentorRepository mentorRepository;
     private final ColumnMapper columnMapper;
 
     public CreateColumnResponseDto createColumnRequest(CreateColumnRequestDto dto, Long mentorId) {
-        // 1. Column 저장
-        Column column = columnMapper.toColumn(dto, mentorId);
+        // 1. Mentor 조회
+        Mentor mentor = mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MENTOR_NOT_FOUND));
+
+        // 2. Column 저장
+        Column column = columnMapper.toColumn(dto, mentor);
         Column savedColumn = columnRepository.save(column);
 
         // 2. ColumnRequest 저장
@@ -90,7 +97,7 @@ public class ColumnRequestService {
 
     public Long getMentorId(Long columnId) {
         return columnRepository.findById(columnId)
-                .map(Column::getMentorId)
+                .map(column -> column.getMentor().getMentorId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_NOT_FOUND));
     }
 }

--- a/src/main/java/com/newbit/column/service/ColumnService.java
+++ b/src/main/java/com/newbit/column/service/ColumnService.java
@@ -50,19 +50,7 @@ public class ColumnService {
 
     public Page<GetColumnListResponseDto> getPublicColumnList(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Column> columnsPage = columnRepository.findAllByIsPublicTrueOrderByCreatedAtDesc(pageable);
 
-        List<GetColumnListResponseDto> dtoList = columnsPage.stream()
-                .map(column -> GetColumnListResponseDto.builder()
-                        .columnId(column.getColumnId())
-                        .title(column.getTitle())
-                        .thumbnailUrl(column.getThumbnailUrl())
-                        .price(column.getPrice())
-                        .likeCount(column.getLikeCount())
-                        .mentorId(column.getMentorId())
-                        .build())
-                .collect(Collectors.toList());
-
-        return new PageImpl<>(dtoList, pageable, columnsPage.getTotalElements());
+        return columnRepository.findAllByIsPublicTrueOrderByCreatedAtDesc(pageable);
     }
 }

--- a/src/main/java/com/newbit/column/service/ColumnService.java
+++ b/src/main/java/com/newbit/column/service/ColumnService.java
@@ -1,6 +1,5 @@
 package com.newbit.column.service;
 
-import com.newbit.column.domain.Column;
 import com.newbit.column.dto.response.GetColumnDetailResponseDto;
 import com.newbit.column.dto.response.GetColumnListResponseDto;
 import com.newbit.column.repository.ColumnRepository;
@@ -9,13 +8,9 @@ import com.newbit.common.exception.ErrorCode;
 import com.newbit.purchase.query.service.ColumnPurchaseHistoryQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,27 +20,15 @@ public class ColumnService {
     private final ColumnPurchaseHistoryQueryService columnPurchaseHistoryQueryService;
 
     public GetColumnDetailResponseDto getColumnDetail(Long userId, Long columnId) {
-        Column column = columnRepository.findById(columnId)
+        GetColumnDetailResponseDto dto = columnRepository.findPublicColumnDetailById(columnId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_NOT_FOUND));
-
-        if (!column.isPublic()) {
-            throw new BusinessException(ErrorCode.COLUMN_NOT_FOUND);
-        }
 
         boolean isPurchased = columnPurchaseHistoryQueryService.hasUserPurchasedColumn(userId, columnId);
         if (!isPurchased) {
             throw new BusinessException(ErrorCode.COLUMN_NOT_PURCHASED);
         }
 
-        return GetColumnDetailResponseDto.builder()
-                .columnId(column.getColumnId())
-                .title(column.getTitle())
-                .content(column.getContent())
-                .price(column.getPrice())
-                .thumbnailUrl(column.getThumbnailUrl())
-                .likeCount(column.getLikeCount())
-                .mentorId(column.getMentorId())
-                .build();
+        return dto;
     }
 
     public Page<GetColumnListResponseDto> getPublicColumnList(int page, int size) {

--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
     COFFEECHAT_NOT_PURCHASABLE("60005", "커피챗이 구매할 수 없는 상태입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_MENTOR("60005", "이미 멘토인 회원입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_POINT("60006", "보유한 포인트가 부족합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    INVALID_PURCHASE_TYPE("60007", "알수없는 재화 타입", HttpStatus.INTERNAL_SERVER_ERROR);
+    INVALID_PURCHASE_TYPE("60007", "알수없는 재화 타입", HttpStatus.INTERNAL_SERVER_ERROR),
+    MENTOR_NOT_FOUND("60008", "해당 멘토를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);;
 
     private final String code;
     private final String message;

--- a/src/test/java/com/newbit/column/service/ColumnServiceTest.java
+++ b/src/test/java/com/newbit/column/service/ColumnServiceTest.java
@@ -2,6 +2,7 @@ package com.newbit.column.service;
 
 import com.newbit.column.domain.Column;
 import com.newbit.column.dto.response.GetColumnDetailResponseDto;
+import com.newbit.column.dto.response.GetColumnListResponseDto;
 import com.newbit.column.repository.ColumnRepository;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
@@ -12,7 +13,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -122,5 +128,57 @@ class ColumnServiceTest {
         assertThatThrownBy(() -> columnService.getColumnDetail(userId, columnId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.COLUMN_NOT_PURCHASED.getMessage());
+    }
+
+    @DisplayName("공개된 칼럼 목록 조회 - 페이징 적용")
+    @Test
+    void getPublicColumnList_paging_success() {
+        // given
+        int page = 0;
+        int size = 2;
+        Pageable pageable = PageRequest.of(page, size);
+
+        Column column1 = Column.builder()
+                .columnId(1L)
+                .title("이직을 위한 포트폴리오 전략")
+                .thumbnailUrl("https://example.com/img1.jpg")
+                .price(1000)
+                .likeCount(12)
+                .mentorId(101L)
+                .isPublic(true)
+                .build();
+
+        Column column2 = Column.builder()
+                .columnId(2L)
+                .title("개발자 연봉 협상법")
+                .thumbnailUrl("https://example.com/img2.jpg")
+                .price(2000)
+                .likeCount(20)
+                .mentorId(102L)
+                .isPublic(true)
+                .build();
+
+        List<Column> columnList = List.of(column1, column2);
+        Page<Column> columnPage = new PageImpl<>(columnList, pageable, columnList.size());
+
+        when(columnRepository.findAllByIsPublicTrueOrderByCreatedAtDesc(pageable)).thenReturn(columnPage);
+
+        // when
+        Page<GetColumnListResponseDto> result = columnService.getPublicColumnList(page, size);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(2);
+
+        GetColumnListResponseDto dto1 = result.getContent().get(0);
+        assertThat(dto1.getColumnId()).isEqualTo(1L);
+        assertThat(dto1.getTitle()).isEqualTo("이직을 위한 포트폴리오 전략");
+
+        GetColumnListResponseDto dto2 = result.getContent().get(1);
+        assertThat(dto2.getColumnId()).isEqualTo(2L);
+        assertThat(dto2.getTitle()).isEqualTo("개발자 연봉 협상법");
     }
 }

--- a/src/test/java/com/newbit/column/service/ColumnServiceTest.java
+++ b/src/test/java/com/newbit/column/service/ColumnServiceTest.java
@@ -50,18 +50,18 @@ class ColumnServiceTest {
         // given
         Long userId = 1L;
         Long columnId = 1L;
-        Column column = Column.builder()
-                .columnId(columnId)
-                .title("테스트 제목")
-                .content("테스트 내용")
-                .price(1000)
-                .thumbnailUrl("https://example.com/image.jpg")
-                .likeCount(5)
-                .mentorId(10L)
-                .isPublic(true)
-                .build();
+        GetColumnDetailResponseDto responseDto = new GetColumnDetailResponseDto(
+                columnId,
+                "테스트 제목",
+                "테스트 내용",
+                1000,
+                "https://example.com/image.jpg",
+                5,
+                10L,
+                "개발자도토리"
+        );
 
-        when(columnRepository.findById(columnId)).thenReturn(Optional.of(column));
+        when(columnRepository.findPublicColumnDetailById(columnId)).thenReturn(Optional.of(responseDto));
         when(columnPurchaseHistoryQueryService.hasUserPurchasedColumn(userId, columnId)).thenReturn(true);
 
         // when
@@ -75,6 +75,7 @@ class ColumnServiceTest {
         assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/image.jpg");
         assertThat(result.getLikeCount()).isEqualTo(5);
         assertThat(result.getMentorId()).isEqualTo(10L);
+        assertThat(result.getMentorNickname()).isEqualTo("개발자도토리");
     }
 
     @DisplayName("비공개 칼럼일 경우 예외 발생")
@@ -138,28 +139,28 @@ class ColumnServiceTest {
         int size = 2;
         Pageable pageable = PageRequest.of(page, size);
 
-        Column column1 = Column.builder()
+        GetColumnListResponseDto dto1 = GetColumnListResponseDto.builder()
                 .columnId(1L)
                 .title("이직을 위한 포트폴리오 전략")
                 .thumbnailUrl("https://example.com/img1.jpg")
                 .price(1000)
                 .likeCount(12)
                 .mentorId(101L)
-                .isPublic(true)
+                .mentorNickname("개발자도토리")
                 .build();
 
-        Column column2 = Column.builder()
+        GetColumnListResponseDto dto2 = GetColumnListResponseDto.builder()
                 .columnId(2L)
                 .title("개발자 연봉 협상법")
                 .thumbnailUrl("https://example.com/img2.jpg")
                 .price(2000)
                 .likeCount(20)
                 .mentorId(102L)
-                .isPublic(true)
+                .mentorNickname("연봉왕")
                 .build();
 
-        List<Column> columnList = List.of(column1, column2);
-        Page<Column> columnPage = new PageImpl<>(columnList, pageable, columnList.size());
+        List<GetColumnListResponseDto> dtoList = List.of(dto1, dto2);
+        Page<GetColumnListResponseDto> columnPage = new PageImpl<>(dtoList, pageable, dtoList.size());
 
         when(columnRepository.findAllByIsPublicTrueOrderByCreatedAtDesc(pageable)).thenReturn(columnPage);
 
@@ -173,12 +174,14 @@ class ColumnServiceTest {
         assertThat(result.getNumber()).isEqualTo(0);
         assertThat(result.getSize()).isEqualTo(2);
 
-        GetColumnListResponseDto dto1 = result.getContent().get(0);
-        assertThat(dto1.getColumnId()).isEqualTo(1L);
-        assertThat(dto1.getTitle()).isEqualTo("이직을 위한 포트폴리오 전략");
+        GetColumnListResponseDto resultDto1 = result.getContent().get(0);
+        assertThat(resultDto1.getColumnId()).isEqualTo(1L);
+        assertThat(resultDto1.getTitle()).isEqualTo("이직을 위한 포트폴리오 전략");
+        assertThat(resultDto1.getMentorNickname()).isEqualTo("개발자도토리");
 
-        GetColumnListResponseDto dto2 = result.getContent().get(1);
-        assertThat(dto2.getColumnId()).isEqualTo(2L);
-        assertThat(dto2.getTitle()).isEqualTo("개발자 연봉 협상법");
+        GetColumnListResponseDto resultDto2 = result.getContent().get(1);
+        assertThat(resultDto2.getColumnId()).isEqualTo(2L);
+        assertThat(resultDto2.getTitle()).isEqualTo("개발자 연봉 협상법");
+        assertThat(resultDto2.getMentorNickname()).isEqualTo("연봉왕");
     }
 }


### PR DESCRIPTION
### 🛰️ Issue
Nbt 156 공개 칼럼 리스트 조회 기능 구현	

### 🪐 작업 내용
1. 공개된 칼럼(isPublic = true)만 조회하는 기능 구현
2. 생성일(createdAt) 기준 내림차순으로 정렬되도록 설정
3. 관련 Repository 메서드 정의:
4. findAllByIsPublicTrueOrderByCreatedAtDesc()
5. 목록 조회 페이징 처리 완료