### PR TITLE
feat: NBT-101 be 게시글 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/newbit/post/controller/PostController.java
+++ b/src/main/java/com/newbit/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.newbit.post.controller;
 
 import com.newbit.post.dto.request.PostCreateRequest;
 import com.newbit.post.dto.request.PostUpdateRequest;
+import com.newbit.post.dto.response.PostDetailResponse;
 import com.newbit.post.dto.response.PostResponse;
 import com.newbit.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,7 +16,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
-
 
 @Tag(name = "게시글 API", description = "게시글 등록, 수정, 삭제, 조회 관련")
 @RestController
@@ -66,6 +66,12 @@ public class PostController {
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
         Page<PostResponse> responses = postService.getPostList(pageable);
         return ResponseEntity.ok(responses);
-
     }
+
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시글 상세 조회", description = "게시글 상세정보를 조회합니다.")
+    public ResponseEntity<PostDetailResponse> getPostDetail(@PathVariable Long postId) {
+        return ResponseEntity.ok(postService.getPostDetail(postId));
+    }
+
 }

--- a/src/main/java/com/newbit/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/newbit/post/dto/response/PostDetailResponse.java
@@ -4,6 +4,7 @@ import com.newbit.post.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -13,6 +14,7 @@ public class PostDetailResponse {
     private String title;
     private String content;
     private int likeCount;
+    private final LocalDateTime createdAt;
     private String writerName;
     private String categoryName;
     private List<CommentResponse> comments;
@@ -22,6 +24,7 @@ public class PostDetailResponse {
         this.title = post.getTitle();
         this.content = post.getContent();
         this.likeCount = post.getLikeCount();
+        this.createdAt = post.getCreatedAt();
         this.writerName = writerName;
         this.categoryName = categoryName;
         this.comments = comments;

--- a/src/main/java/com/newbit/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/newbit/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,29 @@
+package com.newbit.post.dto.response;
+
+import com.newbit.post.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PostDetailResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private int likeCount;
+    private String writerName;
+    private String categoryName;
+    private List<CommentResponse> comments;
+
+    public PostDetailResponse(Post post, List<CommentResponse> comments, String writerName, String categoryName) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.likeCount = post.getLikeCount();
+        this.writerName = writerName;
+        this.categoryName = categoryName;
+        this.comments = comments;
+    }
+}

--- a/src/main/java/com/newbit/post/entity/Post.java
+++ b/src/main/java/com/newbit/post/entity/Post.java
@@ -1,5 +1,6 @@
 package com.newbit.post.entity;
 
+import com.newbit.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -75,4 +76,14 @@ public class Post {
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_category_id", insertable = false, updatable = false)
+    private PostCategory postCategory;
+
+
 }

--- a/src/main/java/com/newbit/post/entity/PostCategory.java
+++ b/src/main/java/com/newbit/post/entity/PostCategory.java
@@ -1,0 +1,41 @@
+package com.newbit.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post_category")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_category_id")
+    private Long id;
+
+    @Column(name = "post_category_name", nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/newbit/post/repository/PostRepository.java
+++ b/src/main/java/com/newbit/post/repository/PostRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR p.content LIKE CONCAT('%', :keyword, '%')")
     List<Post> searchByKeyword(@Param("keyword") String keyword);
+    Optional<Post> findByIdAndDeletedAtIsNull(Long postId);
+
 }


### PR DESCRIPTION
### 🛰️ Issue
close #89 

### 🪐 작업 내용
- 게시글 상세 정보를 조회하는 기능 추가
  - 제목, 내용, 작성일, 수정일 등 기본 정보 포함
  - 삭제된 게시글은 조회되지 않도록 예외 처리

- 연관된 정보 함께 반환:
  - 작성자 이름 (User.userName)
  - 카테고리 이름 (PostCategory.name)
  - 해당 게시글에 달린 댓글 리스트 (Comment)

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] SWAGGER 
- [x] 단위테스트
