### PR TITLE
feat: NBT-147 커피챗 다이아 환불 기능 구현

### DIFF
--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
     COFFEECHAT_NOT_PURCHASABLE("60005", "커피챗이 구매할 수 없는 상태입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_MENTOR("60005", "이미 멘토인 회원입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_POINT("60006", "보유한 포인트가 부족합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    INVALID_PURCHASE_TYPE("60007", "알수없는 재화 타입", HttpStatus.INTERNAL_SERVER_ERROR);
+    INVALID_PURCHASE_TYPE("60007", "알수없는 재화 타입", HttpStatus.INTERNAL_SERVER_ERROR),
+    COFFEECHAT_NOT_REFUNDABLE("60008", "커피챗이 환불 가능한 상태가 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
@@ -149,4 +149,11 @@ public class PurchaseCommandService {
         diamondHistoryRepository.save(DiamondHistory.forCoffeechatRefund(menteeId, coffeechatId, totalPrice, balance));
     }
 
+    // 멘토 멘티 구매 확정시 판매내역 추가 메서드
+    @Transactional
+    public void addSaleHistory(Long mentorId, Integer price, Long serviceId) {
+        SaleHistory saleHistory = SaleHistory.forCoffeechat(mentorId, price, serviceId);
+        saleHistoryRepository.save(saleHistory);
+    }
+
 }

--- a/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
@@ -141,8 +141,7 @@ public class PurchaseCommandService {
     }
 
 
-
-
+    @Transactional
     public void refundCoffeeChat(Long coffeechatId, Long menteeId, Long mentorId, Integer totalPrice) {
 
         // 1. 멘티 다이아 추가

--- a/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
@@ -138,18 +138,19 @@ public class PurchaseCommandService {
         mentorService.createMentor(userId);
     }
 
-
+    // 커피챗 다이아 환불
     @Transactional
-    public void refundCoffeeChat(Long coffeechatId, Long menteeId, Long mentorId, Integer totalPrice) {
+    public void refundCoffeeChat(Long coffeechatId, Long menteeId, Integer totalPrice) {
 
-        // 1. 멘티 다이아 추가
+        // 1. 멘티 다이아 추가 후 현재 다이아값 반환
         Integer balance = userService.addDiamond(menteeId, totalPrice);
 
         // 2. 다이아 내역 저장
         diamondHistoryRepository.save(DiamondHistory.forCoffeechatRefund(menteeId, coffeechatId, totalPrice, balance));
     }
 
-    // 멘토 멘티 구매 확정시 판매내역 추가 메서드
+
+    // 멘토 멘티 구매 확정시 판매내역 추가
     @Transactional
     public void addSaleHistory(Long mentorId, Integer price, Long serviceId) {
         SaleHistory saleHistory = SaleHistory.forCoffeechat(mentorId, price, serviceId);

--- a/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
@@ -2,9 +2,7 @@ package com.newbit.purchase.command.application.service;
 
 import com.newbit.coffeechat.command.application.service.CoffeechatCommandService;
 import com.newbit.coffeechat.query.dto.response.CoffeechatDto;
-import com.newbit.coffeechat.query.dto.response.ProgressStatus;
 import com.newbit.coffeechat.query.service.CoffeechatQueryService;
-import com.newbit.column.repository.ColumnRepository;
 import com.newbit.column.service.ColumnRequestService;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;

--- a/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
@@ -107,9 +107,6 @@ public class PurchaseCommandService {
 
         // 3. 다이아 내역 저장
         diamondHistoryRepository.save(DiamondHistory.forCoffeechatPurchase(menteeId, coffeechatId, totalPrice, balance));
-
-        // 4. 판매 내역 저장
-        saleHistoryRepository.save(SaleHistory.forCoffeechat(mentorId, totalPrice, coffeechatId));
     }
 
 
@@ -144,31 +141,15 @@ public class PurchaseCommandService {
     }
 
 
-    public void refundCoffeeChat(Long coffeechatId) {
-        CoffeechatDto coffeeChat = coffeechatQueryService.getCoffeechat(coffeechatId).getCoffeechat();
-        MentorDTO mentorInfo = mentorService.getMentorInfo(coffeechatId);
-        ProgressStatus coffeechatStatus = coffeeChat.getProgressStatus();
-        Long menteeId = coffeeChat.getMenteeId();
 
 
-        if (!coffeechatStatus.equals(ProgressStatus.COMPLETE)) {
-            throw new BusinessException(ErrorCode.COFFEECHAT_NOT_REFUNDABLE);
-        }
-
-        int totalPrice = coffeeChat.getPurchaseQuantity() * mentorInfo.getPrice();
+    public void refundCoffeeChat(Long coffeechatId, Long menteeId, Long mentorId, Integer totalPrice) {
 
         // 1. 멘티 다이아 추가
         Integer balance = userService.addDiamond(menteeId, totalPrice);
 
-        // 2. 커피챗 상태 변경 + 구매일시 < 환불 요청한 쪽에서 해결할 가능성 있음
-//      coffeechatQueryService.markAsPurchased();
-
-        // 5. 다이아 내역 저장
+        // 2. 다이아 내역 저장
         diamondHistoryRepository.save(DiamondHistory.forCoffeechatRefund(menteeId, coffeechatId, totalPrice, balance));
-
-        // 6. 판매 내역 저장
-        saleHistoryRepository.save(SaleHistory.forCoffeechat(mentorId, totalPrice, coffeechatId));
-
     }
 
 }

--- a/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondHistory.java
+++ b/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondHistory.java
@@ -94,4 +94,15 @@ public class DiamondHistory {
                 .balance(diamond)  // 차감 이후 잔액
                 .build();
     }
+
+    public static DiamondHistory forCoffeechatRefund(Long userId, Long coffeechatId, int totalPrice, Integer diamondBalance) {
+        return DiamondHistory.builder()
+                .userId(userId)
+                .serviceType(DiamondTransactionType.COFFEECHAT)
+                .serviceId(coffeechatId)
+                .decreaseAmount(totalPrice)
+                .increaseAmount(null)
+                .balance(diamondBalance)  // 차감 이후 잔액
+                .build();
+    }
 }

--- a/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondHistory.java
+++ b/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondHistory.java
@@ -100,8 +100,8 @@ public class DiamondHistory {
                 .userId(userId)
                 .serviceType(DiamondTransactionType.COFFEECHAT)
                 .serviceId(coffeechatId)
-                .decreaseAmount(totalPrice)
-                .increaseAmount(null)
+                .decreaseAmount(null)
+                .increaseAmount(totalPrice)
                 .balance(diamondBalance)  // 차감 이후 잔액
                 .build();
     }

--- a/src/main/java/com/newbit/user/entity/User.java
+++ b/src/main/java/com/newbit/user/entity/User.java
@@ -78,6 +78,11 @@ public class User {
         this.diamond -= amount;
     }
 
+    // 보유 다이아 증가
+    public void addDiamond(int amount) {
+        this.diamond += amount;
+    }
+
     // 보유 포인트 차감
     public void usePoint(int amount) {
         if (this.point < amount) {
@@ -98,4 +103,6 @@ public class User {
     public void findPassword(String newPassword) {
         this.password = newPassword;
     }
+
+
 }

--- a/src/main/java/com/newbit/user/service/UserService.java
+++ b/src/main/java/com/newbit/user/service/UserService.java
@@ -96,6 +96,14 @@ public class UserService {
     }
 
     @Transactional
+    public Integer addDiamond(Long userId, int amount) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.addDiamond(amount);// 도메인 로직에 위임 (Entity 내부에 구현된 로직)
+        return user.getDiamond();
+    }
+
+    @Transactional
     public Integer usePoint(Long userId, int amount) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -120,4 +128,6 @@ public class UserService {
                 .point(user.getPoint())
                 .build();
     }
+
+
 }

--- a/src/main/java/com/newbit/user/service/UserService.java
+++ b/src/main/java/com/newbit/user/service/UserService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.Optional;
 
 import java.util.UUID;
 

--- a/src/test/java/com/newbit/purchase/command/application/service/PurchaseCommandServiceTest.java
+++ b/src/test/java/com/newbit/purchase/command/application/service/PurchaseCommandServiceTest.java
@@ -285,7 +285,7 @@ class PurchaseCommandServiceTest {
         Long coffeechatId = 1L;
         Long menteeId = 100L;
         Long mentorId = 200L;
-        Integer refundAmount = 5000;
+        int refundAmount = 5000;
         Integer updatedBalance = 10000;
 
         // 멘티 다이아 추가 후 새로운 잔액 리턴
@@ -298,7 +298,7 @@ class PurchaseCommandServiceTest {
         when(diamondHistoryRepository.save(any(DiamondHistory.class))).thenReturn(mockHistory);
 
         // when
-        purchaseCommandService.refundCoffeeChat(coffeechatId, menteeId, mentorId, refundAmount);
+        purchaseCommandService.refundCoffeeChat(coffeechatId, menteeId, refundAmount);
 
         // then
         verify(userService).addDiamond(menteeId, refundAmount);

--- a/src/test/java/com/newbit/purchase/command/application/service/PurchaseCommandServiceTest.java
+++ b/src/test/java/com/newbit/purchase/command/application/service/PurchaseCommandServiceTest.java
@@ -19,15 +19,12 @@ import com.newbit.user.dto.response.MentorDTO;
 import com.newbit.user.service.MentorService;
 import com.newbit.user.dto.response.UserDTO;
 import com.newbit.user.entity.Authority;
-import com.newbit.user.service.MentorService;
 import com.newbit.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.awt.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
### 🛰️ Issue
feat: NBT-147 커피챗 다이아 환불 기능 구현 (close #164)

### 🪐 작업 내용
- 커피챗 다이아 환불요청시 다이아 내역 테이블에 내역 생성
- 환불 요청한 회원의 보유 다이아 값 변경(증가)
- 커피챗 구매, 커피챗 환불시 판매내역 내역 생성 메서드 호출 삭제 후 메서드 분리

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] 테스트 코드 작성 

