### PR TITLE
feat:NBT-145-be-신고-50-회-누적-댓글-자동-soft-delete-기능-시스템'

### DIFF
--- a/src/main/java/com/newbit/report/command/application/service/ReportCommandService.java
+++ b/src/main/java/com/newbit/report/command/application/service/ReportCommandService.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.newbit.post.entity.Comment;
 import com.newbit.post.entity.Post;
+import com.newbit.post.repository.CommentRepository;
 import com.newbit.post.repository.PostRepository;
 import com.newbit.report.command.application.dto.request.ReportCreateRequest;
 import com.newbit.report.command.application.dto.response.ReportCommandResponse;
@@ -14,7 +16,6 @@ import com.newbit.report.command.domain.aggregate.ReportStatus;
 import com.newbit.report.command.domain.aggregate.ReportType;
 import com.newbit.report.command.domain.repository.ReportRepository;
 import com.newbit.report.command.domain.repository.ReportTypeRepository;
-import com.newbit.report.command.infrastructure.repository.JpaReportRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,7 +27,7 @@ public class ReportCommandService {
     private final ReportRepository reportRepository;
     private final ReportTypeRepository reportTypeRepository;
     private final PostRepository postRepository;
-    private final JpaReportRepository jpaReportRepository;
+    private final CommentRepository commentRepository;
 
     private static final int REPORT_THRESHOLD = 50;
 
@@ -69,6 +70,8 @@ public class ReportCommandService {
         
         Report savedReport = reportRepository.save(report);
         
+        incrementCommentReportCount(request.getCommentId());
+        
         return new ReportCommandResponse(savedReport);
     }
     
@@ -81,7 +84,27 @@ public class ReportCommandService {
         if (post.getReportCount() >= REPORT_THRESHOLD) {
             post.softDelete();
             
-            List<Report> reports = jpaReportRepository.findAllByPostId(postId);
+            List<Report> reports = reportRepository.findAllByPostId(postId);
+            for (Report report : reports) {
+                report.updateStatus(ReportStatus.DELETED);
+            }
+            
+            return true;
+        }
+        
+        return false;
+    }
+    
+    private boolean incrementCommentReportCount(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+        
+        comment.setReportCount(comment.getReportCount() + 1);
+        
+        if (comment.getReportCount() >= REPORT_THRESHOLD) {
+            comment.softDelete();
+            
+            List<Report> reports = reportRepository.findAllByCommentId(commentId);
             for (Report report : reports) {
                 report.updateStatus(ReportStatus.DELETED);
             }
@@ -100,11 +123,18 @@ public class ReportCommandService {
         
         report.updateStatus(newStatus);
         
-        if (newStatus == ReportStatus.DELETED && report.getPostId() != null) {
-            Post post = postRepository.findById(report.getPostId())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
-            
-            post.softDelete();
+        if (newStatus == ReportStatus.DELETED) {
+            if (report.getPostId() != null) {
+                Post post = postRepository.findById(report.getPostId())
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                
+                post.softDelete();
+            } else if (report.getCommentId() != null) {
+                Comment comment = commentRepository.findById(report.getCommentId())
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+                
+                comment.softDelete();
+            }
         }
         
         return new ReportCommandResponse(report);

--- a/src/main/java/com/newbit/report/command/domain/repository/ReportRepository.java
+++ b/src/main/java/com/newbit/report/command/domain/repository/ReportRepository.java
@@ -1,5 +1,7 @@
 package com.newbit.report.command.domain.repository;
 
+import java.util.List;
+
 import com.newbit.report.command.domain.aggregate.Report;
 
 public interface ReportRepository {
@@ -7,4 +9,8 @@ public interface ReportRepository {
     Report save(Report report);
     
     Report findById(Long id);
+    
+    List<Report> findAllByPostId(Long postId);
+    
+    List<Report> findAllByCommentId(Long commentId);
 }

--- a/src/main/java/com/newbit/report/command/infrastructure/repository/JpaReportRepository.java
+++ b/src/main/java/com/newbit/report/command/infrastructure/repository/JpaReportRepository.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 interface JpaReportJpaRepository extends JpaRepository<Report, Long> {
     List<Report> findAllByPostId(Long postId);
+    List<Report> findAllByCommentId(Long commentId);
 }
 
 @Repository
@@ -32,5 +33,9 @@ public class JpaReportRepository implements ReportRepository {
     
     public List<Report> findAllByPostId(Long postId) {
         return jpaRepository.findAllByPostId(postId);
+    }
+    
+    public List<Report> findAllByCommentId(Long commentId) {
+        return jpaRepository.findAllByCommentId(commentId);
     }
 }

--- a/src/test/java/com/newbit/report/command/application/service/ReportCommandServiceTest.java
+++ b/src/test/java/com/newbit/report/command/application/service/ReportCommandServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
@@ -19,7 +18,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.newbit.post.entity.Comment;
 import com.newbit.post.entity.Post;
+import com.newbit.post.repository.CommentRepository;
 import com.newbit.post.repository.PostRepository;
 import com.newbit.report.command.application.dto.request.ReportCreateRequest;
 import com.newbit.report.command.application.dto.response.ReportCommandResponse;
@@ -28,7 +29,6 @@ import com.newbit.report.command.domain.aggregate.ReportStatus;
 import com.newbit.report.command.domain.aggregate.ReportType;
 import com.newbit.report.command.domain.repository.ReportRepository;
 import com.newbit.report.command.domain.repository.ReportTypeRepository;
-import com.newbit.report.command.infrastructure.repository.JpaReportRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ReportCommandServiceTest {
@@ -43,7 +43,7 @@ class ReportCommandServiceTest {
     private PostRepository postRepository;
     
     @Mock
-    private JpaReportRepository jpaReportRepository;
+    private CommentRepository commentRepository;
     
     @InjectMocks
     private ReportCommandService reportCommandService;
@@ -61,18 +61,10 @@ class ReportCommandServiceTest {
         
         // ReportType 모킹
         ReportType reportType = mock(ReportType.class);
-        when(reportType.getId()).thenReturn(reportTypeId);
         when(reportTypeRepository.findById(reportTypeId)).thenReturn(Optional.of(reportType));
         
         // Report 모킹
         Report report = mock(Report.class);
-        when(report.getReportId()).thenReturn(1L);
-        when(report.getUserId()).thenReturn(userId);
-        when(report.getPostId()).thenReturn(postId);
-        when(report.getReportType()).thenReturn(reportType);
-        when(report.getContent()).thenReturn(content);
-        when(report.getStatus()).thenReturn(ReportStatus.SUBMITTED);
-        
         when(reportRepository.save(any(Report.class))).thenReturn(report);
         
         // Post 모킹
@@ -117,18 +109,10 @@ class ReportCommandServiceTest {
         
         // ReportType 모킹
         ReportType reportType = mock(ReportType.class);
-        when(reportType.getId()).thenReturn(reportTypeId);
         when(reportTypeRepository.findById(reportTypeId)).thenReturn(Optional.of(reportType));
         
         // Report 모킹
         Report report = mock(Report.class);
-        when(report.getReportId()).thenReturn(1L);
-        when(report.getUserId()).thenReturn(userId);
-        when(report.getPostId()).thenReturn(postId);
-        when(report.getReportType()).thenReturn(reportType);
-        when(report.getContent()).thenReturn(content);
-        when(report.getStatus()).thenReturn(ReportStatus.SUBMITTED);
-        
         when(reportRepository.save(any(Report.class))).thenReturn(report);
         when(postRepository.findById(postId)).thenReturn(Optional.of(postWithHighReportCount));
         
@@ -136,7 +120,7 @@ class ReportCommandServiceTest {
         Report mockReport1 = mock(Report.class);
         Report mockReport2 = mock(Report.class);
         List<Report> reportList = Arrays.asList(mockReport1, mockReport2);
-        when(jpaReportRepository.findAllByPostId(postId)).thenReturn(reportList);
+        when(reportRepository.findAllByPostId(postId)).thenReturn(reportList);
         
         // When
         ReportCommandResponse response = reportCommandService.createPostReport(postReportRequest);
@@ -145,7 +129,7 @@ class ReportCommandServiceTest {
         assertNotNull(response);
         assertEquals(50, postWithHighReportCount.getReportCount()); // 50개로 증가
         assertNotNull(postWithHighReportCount.getDeletedAt()); // 삭제일시 설정됨
-        verify(jpaReportRepository, times(1)).findAllByPostId(postId);
+        verify(reportRepository, times(1)).findAllByPostId(postId);
     }
     
     @Test
@@ -156,7 +140,6 @@ class ReportCommandServiceTest {
         
         // Report 모킹
         Report report = mock(Report.class);
-        when(report.getReportId()).thenReturn(reportId);
         when(reportRepository.findById(reportId)).thenReturn(report);
         
         // When
@@ -179,6 +162,7 @@ class ReportCommandServiceTest {
         Report report = mock(Report.class);
         when(report.getReportId()).thenReturn(reportId);
         when(report.getPostId()).thenReturn(postId);
+        when(report.getCommentId()).thenReturn(null);
         when(reportRepository.findById(reportId)).thenReturn(report);
         
         // Post 모킹
@@ -200,5 +184,148 @@ class ReportCommandServiceTest {
         assertNotNull(post.getDeletedAt()); // 삭제일시 설정됨
         verify(reportRepository, times(1)).findById(reportId);
         verify(postRepository, times(1)).findById(postId);
+    }
+    
+    @Test
+    @DisplayName("댓글 신고 생성 테스트")
+    void createCommentReportTest() {
+        // Given
+        Long userId = 1L;
+        Long commentId = 1L;
+        Long reportTypeId = 1L;
+        String content = "댓글 신고 내용";
+        
+        ReportCreateRequest commentReportRequest = new ReportCreateRequest(userId, commentId, reportTypeId, content, true);
+        
+        // ReportType 모킹
+        ReportType reportType = mock(ReportType.class);
+        when(reportTypeRepository.findById(reportTypeId)).thenReturn(Optional.of(reportType));
+        
+        // Report 모킹
+        Report report = mock(Report.class);
+        when(reportRepository.save(any(Report.class))).thenReturn(report);
+        
+        // Comment 모킹
+        Post post = Post.builder()
+                .id(1L)
+                .title("테스트 게시글")
+                .content("테스트 내용")
+                .userId(2L)
+                .build();
+                
+        Comment comment = Comment.builder()
+                .id(commentId)
+                .content("테스트 댓글")
+                .userId(2L)
+                .post(post)
+                .reportCount(0)
+                .build();
+        
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        
+        // When
+        ReportCommandResponse response = reportCommandService.createCommentReport(commentReportRequest);
+        
+        // Then
+        assertNotNull(response);
+        assertEquals(1, comment.getReportCount()); // 신고 횟수 증가 확인
+        verify(reportRepository, times(1)).save(any(Report.class));
+        verify(commentRepository, times(1)).findById(commentId);
+    }
+    
+    @Test
+    @DisplayName("댓글 신고 횟수 임계값(50) 도달 시 댓글 삭제 테스트")
+    void commentReportThresholdTest() {
+        // Given
+        Long userId = 1L;
+        Long commentId = 1L;
+        Long reportTypeId = 1L;
+        String content = "댓글 신고 내용";
+        
+        ReportCreateRequest commentReportRequest = new ReportCreateRequest(userId, commentId, reportTypeId, content, true);
+        
+        // 임계값 직전의 댓글 설정
+        Post post = Post.builder()
+                .id(1L)
+                .title("테스트 게시글")
+                .content("테스트 내용")
+                .userId(2L)
+                .build();
+                
+        Comment commentWithHighReportCount = Comment.builder()
+                .id(commentId)
+                .content("신고가 많은 댓글")
+                .userId(2L)
+                .post(post)
+                .reportCount(49) // 임계값 직전
+                .build();
+        
+        // ReportType 모킹
+        ReportType reportType = mock(ReportType.class);
+        when(reportTypeRepository.findById(reportTypeId)).thenReturn(Optional.of(reportType));
+        
+        // Report 모킹
+        Report report = mock(Report.class);
+        when(reportRepository.save(any(Report.class))).thenReturn(report);
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(commentWithHighReportCount));
+        
+        // 관련 신고 리스트 모킹
+        Report mockReport1 = mock(Report.class);
+        Report mockReport2 = mock(Report.class);
+        List<Report> reportList = Arrays.asList(mockReport1, mockReport2);
+        when(reportRepository.findAllByCommentId(commentId)).thenReturn(reportList);
+        
+        // When
+        ReportCommandResponse response = reportCommandService.createCommentReport(commentReportRequest);
+        
+        // Then
+        assertNotNull(response);
+        assertEquals(50, commentWithHighReportCount.getReportCount()); // 50개로 증가
+        assertNotNull(commentWithHighReportCount.getDeletedAt()); // 삭제일시 설정됨
+        verify(reportRepository, times(1)).findAllByCommentId(commentId);
+        verify(mockReport1, times(1)).updateStatus(ReportStatus.DELETED);
+        verify(mockReport2, times(1)).updateStatus(ReportStatus.DELETED);
+    }
+    
+    @Test
+    @DisplayName("관리자가 댓글 신고를 처리하고 삭제 결정 테스트")
+    void processReportAndDeleteCommentTest() {
+        // Given
+        Long reportId = 1L;
+        Long commentId = 2L;
+        
+        // Report 모킹
+        Report report = mock(Report.class);
+        when(report.getReportId()).thenReturn(reportId);
+        when(report.getPostId()).thenReturn(null);
+        when(report.getCommentId()).thenReturn(commentId);
+        when(reportRepository.findById(reportId)).thenReturn(report);
+        
+        // Comment 모킹
+        Post post = Post.builder()
+                .id(1L)
+                .title("테스트 게시글")
+                .content("테스트 내용")
+                .userId(2L)
+                .build();
+                
+        Comment comment = Comment.builder()
+                .id(commentId)
+                .content("테스트 댓글")
+                .userId(2L)
+                .post(post)
+                .build();
+        
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        
+        // When
+        ReportCommandResponse response = reportCommandService.processReport(reportId, ReportStatus.DELETED);
+        
+        // Then
+        assertNotNull(response);
+        verify(report, times(1)).updateStatus(ReportStatus.DELETED);
+        assertNotNull(comment.getDeletedAt()); // 삭제일시 설정됨
+        verify(reportRepository, times(1)).findById(reportId);
+        verify(commentRepository, times(1)).findById(commentId);
     }
 } 


### PR DESCRIPTION
### 🛰️ Issue
Close #158

### 🪐 작업 내용
- 댓글 자동 삭제(Soft delete) 기능을 구현한다.
- 신고 등록시 댓글의 신고 카운트가 +1 증가하고, 신고 카운트가 50(임계치)를 넘길 시 자동으로 삭제

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] 단위 테스트 작성 
- [x] 통합 테스트 작성
