### PR TITLE
Nbt 106 be 공지사항 등록 기능 구현

### DIFF
--- a/src/main/java/com/newbit/post/controller/PostController.java
+++ b/src/main/java/com/newbit/post/controller/PostController.java
@@ -86,4 +86,22 @@ public class PostController {
         return ResponseEntity.ok(myPosts);
     }
 
+    @GetMapping("/popular")
+    @Operation(summary = "인기 게시글 조회", description = "좋아요 10개 이상 받은 게시글을 좋아요 순으로 조회합니다.")
+    public ResponseEntity<List<PostResponse>> getPopularPosts() {
+        List<PostResponse> responses = postService.getPopularPosts();
+        return ResponseEntity.ok(responses);
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/notices")
+    @Operation(summary = "공지사항 등록", description = "관리자만 공지사항을 등록할 수 있습니다.")
+    public ResponseEntity<PostResponse> createNotice(
+            @RequestBody @Valid PostCreateRequest request,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        PostResponse response = postService.createNotice(request, user);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/newbit/post/repository/PostRepository.java
+++ b/src/main/java/com/newbit/post/repository/PostRepository.java
@@ -14,6 +14,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> searchByKeyword(@Param("keyword") String keyword);
     Optional<Post> findByIdAndDeletedAtIsNull(Long postId);
     List<Post> findByUserIdAndDeletedAtIsNull(Long userId);
+    @Query("SELECT p FROM Post p WHERE p.deletedAt IS NULL AND p.likeCount >= :minLikes ORDER BY p.likeCount DESC")
+    List<Post> findPopularPosts(@Param("minLikes") int minLikes);
 
 
 }

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -92,4 +92,12 @@ public class PostService {
                 .map(PostResponse::new)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public List<PostResponse> getPopularPosts() {
+        List<Post> posts = postRepository.findPopularPosts(10); // 좋아요 10개 이상
+        return posts.stream()
+                .map(PostResponse::new)
+                .toList();
+    }
 }

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.newbit.post.service;
 
+import com.newbit.auth.model.CustomUser;
 import com.newbit.post.dto.request.PostCreateRequest;
 import com.newbit.post.dto.request.PostUpdateRequest;
 import com.newbit.post.dto.response.CommentResponse;
@@ -99,5 +100,30 @@ public class PostService {
         return posts.stream()
                 .map(PostResponse::new)
                 .toList();
+    }
+
+    @Transactional
+    public PostResponse createNotice(PostCreateRequest request, CustomUser user) {
+        // 🔐 관리자 권한 체크
+        boolean isAdmin = user.getAuthorities().stream()
+                .anyMatch(auth -> "ROLE_ADMIN".equals(auth.getAuthority()));
+
+        if (!isAdmin) {
+            throw new SecurityException("공지사항은 관리자만 등록할 수 있습니다.");
+        }
+
+        // 📝 게시글 생성
+        Post post = Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .userId(user.getUserId())
+                .postCategoryId(request.getPostCategoryId())
+                .likeCount(0)
+                .reportCount(0)
+                .isNotice(true)
+                .build();
+
+        postRepository.save(post);
+        return new PostResponse(post);
     }
 }

--- a/src/test/java/com/newbit/post/service/PostServiceNoticeTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceNoticeTest.java
@@ -1,0 +1,86 @@
+package com.newbit.post.service;
+
+import com.newbit.auth.model.CustomUser;
+import com.newbit.post.dto.request.PostCreateRequest;
+import com.newbit.post.dto.response.PostResponse;
+import com.newbit.post.entity.Post;
+import com.newbit.post.repository.PostRepository;
+import com.newbit.post.service.PostService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PostServiceNoticeTest {
+
+    private PostRepository postRepository;
+    private PostService postService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        postService = new PostService(postRepository, null); // 댓글은 필요 없음
+    }
+
+    @Test
+    void 공지사항_등록_성공_관리자_권한() {
+        // given
+        PostCreateRequest request = new PostCreateRequest();
+        request.setTitle("공지사항입니다");
+        request.setContent("중요한 공지입니다.");
+        request.setPostCategoryId(1L);
+
+        CustomUser adminUser = CustomUser.builder()
+                .userId(1L)
+                .email("admin@example.com")
+                .password("encoded")
+                .authorities(Collections.singleton(() -> "ROLE_ADMIN"))
+                .build();
+
+        // Post 저장 시 반환될 객체 설정
+        Post mockPost = Post.builder()
+                .id(1L)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .userId(adminUser.getUserId())
+                .postCategoryId(request.getPostCategoryId())
+                .isNotice(true)
+                .build();
+
+        when(postRepository.save(any(Post.class))).thenReturn(mockPost);
+
+        // when
+        PostResponse result = postService.createNotice(request, adminUser);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("공지사항입니다");
+        assertThat(result.isNotice()).isTrue();
+        verify(postRepository, times(1)).save(any(Post.class));
+    }
+
+    @Test
+    void 공지사항_등록_실패_권한없음() {
+        // given
+        PostCreateRequest request = new PostCreateRequest();
+        request.setTitle("공지사항입니다");
+        request.setContent("중요한 공지입니다.");
+        request.setPostCategoryId(1L);
+
+        CustomUser normalUser = CustomUser.builder()
+                .userId(2L)
+                .email("user@example.com")
+                .password("encoded")
+                .authorities(Collections.singleton(() -> "ROLE_USER"))
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> postService.createNotice(request, normalUser))
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("공지사항은 관리자만 등록할 수 있습니다.");
+
+        verify(postRepository, never()).save(any(Post.class));
+    }
+}

--- a/src/test/java/com/newbit/post/service/PostServiceTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceTest.java
@@ -252,5 +252,39 @@ class PostServiceTest {
         verify(postRepository, times(1)).findByUserIdAndDeletedAtIsNull(userId);
     }
 
+    @Test
+    void 인기_게시글_조회_성공() {
+        // given
+        Post post1 = Post.builder()
+                .id(1L)
+                .title("인기글 1")
+                .content("내용 1")
+                .likeCount(15)
+                .userId(1L)
+                .postCategoryId(1L)
+                .build();
 
+        Post post2 = Post.builder()
+                .id(2L)
+                .title("인기글 2")
+                .content("내용 2")
+                .likeCount(12)
+                .userId(2L)
+                .postCategoryId(1L)
+                .build();
+
+        List<Post> popularPosts = List.of(post1, post2);
+
+        when(postRepository.findPopularPosts(10)).thenReturn(popularPosts);
+
+        // when
+        List<PostResponse> result = postService.getPopularPosts();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("인기글 1");
+        assertThat(result.get(1).getTitle()).isEqualTo("인기글 2");
+
+        verify(postRepository, times(1)).findPopularPosts(10);
+    }
 }


### PR DESCRIPTION
### 🛰️ Issue
close #94 

### 🪐 작업 내용
 - 공지사항 등록 기능 추가 (POST /posts/notices)
 - 관리자(ADMIN 권한)만 등록 가능하도록 권한 검사 로직 적용
 - 일반 게시글과 구분하기 위해 isNotice = true로 저장

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] SWAGGER 
- [x] 단위테스트
