### PR TITLE
Nbt 105 be 공지사항 삭제 기능 구현

### DIFF
--- a/src/main/java/com/newbit/post/controller/PostController.java
+++ b/src/main/java/com/newbit/post/controller/PostController.java
@@ -116,4 +116,15 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/notices/{postId}")
+    @Operation(summary = "공지사항 삭제", description = "관리자가 공지사항을 삭제합니다.")
+    public ResponseEntity<Void> deleteNotice(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        postService.deleteNotice(postId, user);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -152,4 +152,23 @@ public class PostService {
         return new PostResponse(post);
     }
 
+    @Transactional
+    public void deleteNotice(Long postId, CustomUser user) {
+        boolean isAdmin = user.getAuthorities().stream()
+                .anyMatch(auth -> "ROLE_ADMIN".equals(auth.getAuthority()));
+
+        if (!isAdmin) {
+            throw new SecurityException("공지사항은 관리자만 삭제할 수 있습니다.");
+        }
+
+        Post post = postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        if (!post.isNotice()) {
+            throw new IllegalArgumentException("해당 게시글은 공지사항이 아닙니다.");
+        }
+
+        post.softDelete();
+    }
+
 }


### PR DESCRIPTION
### 🛰️ Issue
close #93 	

### 🪐 작업 내용
관리자 전용 공지사항 삭제 기능 구현
로그인한 사용자 권한이 ROLE_ADMIN일 경우에만 삭제 가능
권한 없을 경우 SecurityException 발생

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] SWAGGER
- [x] 단위테스트
