### PR TITLE
feat: NBT-148 SSE 알림 연결 구현

### DIFF
--- a/src/main/java/com/newbit/notification/command/application/config/SseEmitterStorageConfig.java
+++ b/src/main/java/com/newbit/notification/command/application/config/SseEmitterStorageConfig.java
@@ -1,0 +1,16 @@
+package com.newbit.notification.command.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class SseEmitterStorageConfig {
+    @Bean
+    public Map<String, SseEmitter> sseEmitters() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -1,0 +1,39 @@
+package com.newbit.notification.command.application.controller;
+
+import com.newbit.auth.model.CustomUser;
+import com.newbit.notification.command.infrastructure.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/v1/notification")
+@RequiredArgsConstructor
+public class NotificationCommandController {
+
+    private final SseEmitterRepository sseEmitterRepository;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        SseEmitter emitter = new SseEmitter(60 * 1000L);
+        sseEmitterRepository.addEmitter(userId, emitter);
+
+        emitter.onCompletion(() -> sseEmitterRepository.removeEmitter(userId));
+        emitter.onTimeout(() -> sseEmitterRepository.removeEmitter(userId));
+        emitter.onError((e) -> sseEmitterRepository.removeEmitter(userId));
+
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("SSE 연결 성공"));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+}

--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -21,6 +21,7 @@ public class NotificationCommandController {
     public SseEmitter subscribe(
             @AuthenticationPrincipal CustomUser customUser
     ) {
+        Long userId = customUser.getUserId();
         SseEmitter emitter = new SseEmitter(60 * 1000L);
         sseEmitterRepository.addEmitter(userId, emitter);
 

--- a/src/main/java/com/newbit/notification/command/infrastructure/SseEmitterRepository.java
+++ b/src/main/java/com/newbit/notification/command/infrastructure/SseEmitterRepository.java
@@ -1,0 +1,19 @@
+package com.newbit.notification.command.infrastructure;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class SseEmitterRepository {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void addEmitter(Long userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
+    }
+
+    public void removeEmitter(Long userId) {
+        emitters.remove(userId);
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
NBT-148 SSE 알림 연결 구현(close #165)

### 🪐 작업 내용
- SseEmitter를 활용한 알림 구독 엔드포인트(/subscribe) 구현
- 최초 연결 시 "SSE 연결 성공" 메시지 전송 추가

<img width="925" alt="image" src="https://github.com/user-attachments/assets/f235d0a3-b41c-4713-8da4-70ea02e7f4dc" />


### ✅ Check List (선택)
- [x] Postman 에서 SSE 연결 확인
