### PR TITLE
fix: 게시글 수정 시 인증된 사용자만 가능하도록 기능 추가

### DIFF
--- a/src/main/java/com/newbit/common/config/SwaggerConfig.java
+++ b/src/main/java/com/newbit/common/config/SwaggerConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
 
     @Bean
     public OpenAPI customOpenAPI() {

--- a/src/main/java/com/newbit/post/controller/PostController.java
+++ b/src/main/java/com/newbit/post/controller/PostController.java
@@ -30,10 +30,15 @@ public class PostController {
 
     private final PostService postService;
 
+    @PreAuthorize("isAuthenticated()")
     @PutMapping("/{id}")
     @Operation(summary = "게시글 수정", description = "기존 게시글의 제목과 내용을 수정합니다.")
-    public ResponseEntity<PostResponse> updatePost(@PathVariable Long id, @RequestBody @Valid PostUpdateRequest request) {
-        PostResponse response = postService.updatePost(id, request);
+    public ResponseEntity<PostResponse> updatePost(
+            @PathVariable Long id,
+            @RequestBody @Valid PostUpdateRequest request,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        PostResponse response = postService.updatePost(id, request, user);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -29,9 +29,14 @@ public class PostService {
     private final PointTransactionCommandService pointTransactionCommandService;
 
     @Transactional
-    public PostResponse updatePost(Long postId, PostUpdateRequest request) {
+    public PostResponse updatePost(Long postId, PostUpdateRequest request, CustomUser user) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        // 🔒 작성자 본인 확인
+        if (!post.getUserId().equals(user.getUserId())) {
+            throw new SecurityException("게시글은 작성자만 수정할 수 있습니다.");
+        }
 
         post.update(request.getTitle(), request.getContent());
         return new PostResponse(post);


### PR DESCRIPTION
### 🪐 작업 내용
 - 게시글 수정 시 인증된 사용자만 접근 가능하도록 변경
  - 기존에는 인증 없이도 게시글 수정 요청이 가능했으나, @PreAuthorize("isAuthenticated()") 어노테이션을 컨트롤러에 추가하여 인증 필수로 설정함

 - 게시글 작성자만 수정 가능하도록 서비스 로직 강화
  - 게시글의 userId와 현재 로그인한 사용자의 userId를 비교하여 일치하지 않을 경우 SecurityException 발생

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] SWAGGER 
- [x] 단위테스트
