### PR TITLE
Nbt 87 be 시리즈 생성 기능 구현

### DIFF
--- a/src/main/java/com/newbit/column/controller/SeriesController.java
+++ b/src/main/java/com/newbit/column/controller/SeriesController.java
@@ -1,0 +1,34 @@
+package com.newbit.column.controller;
+
+import com.newbit.auth.model.CustomUser;
+import com.newbit.column.dto.request.CreateSeriesRequestDto;
+import com.newbit.column.dto.response.CreateSeriesResponseDto;
+import com.newbit.column.service.SeriesService;
+import com.newbit.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/series")
+@Tag(name = "Series", description = "시리즈 관련 API")
+public class SeriesController {
+
+    private final SeriesService seriesService;
+
+    @PostMapping
+    @Operation(summary = "시리즈 생성", description = "기존 칼럼을 묶어 시리즈를 생성합니다.")
+    public ApiResponse<CreateSeriesResponseDto> createSeries(
+            @RequestBody @Valid CreateSeriesRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+            ) {
+        return ApiResponse.success(seriesService.createSeries(dto, customUser.getUserId()));
+    }
+}

--- a/src/main/java/com/newbit/column/domain/Column.java
+++ b/src/main/java/com/newbit/column/domain/Column.java
@@ -58,8 +58,16 @@ public class Column {
     @JoinColumn(name = "mentor_id")
     private Mentor mentor;
 
+    @ManyToOne
+    @JoinColumn(name = "series_id")
+    private Series series;
+
 
     public void markAsDeleted() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void updateSeries(Series series) {
+        this.series = series;
     }
 }

--- a/src/main/java/com/newbit/column/domain/Series.java
+++ b/src/main/java/com/newbit/column/domain/Series.java
@@ -1,0 +1,40 @@
+package com.newbit.column.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.*;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "series")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Series {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seriesId;
+
+    private String title;
+
+    private String description;
+
+    private String thumbnailUrl;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "series", cascade = CascadeType.PERSIST)
+    private List<Column> columns = new ArrayList<>();
+}

--- a/src/main/java/com/newbit/column/dto/request/CreateSeriesRequestDto.java
+++ b/src/main/java/com/newbit/column/dto/request/CreateSeriesRequestDto.java
@@ -3,11 +3,13 @@ package com.newbit.column.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class CreateSeriesRequestDto {
 
     @Schema(description = "시리즈 제목", example = "이직 준비 A to Z")

--- a/src/main/java/com/newbit/column/dto/request/CreateSeriesRequestDto.java
+++ b/src/main/java/com/newbit/column/dto/request/CreateSeriesRequestDto.java
@@ -1,0 +1,28 @@
+package com.newbit.column.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CreateSeriesRequestDto {
+
+    @Schema(description = "시리즈 제목", example = "이직 준비 A to Z")
+    @NotBlank
+    private String title;
+
+    @Schema(description = "시리즈 설명", example = "이직을 준비하는 멘티들을 위한 시리즈입니다.")
+    @NotBlank
+    private String description;
+
+    @Schema(description = "대표 이미지 URL", example = "https://example.com/img.jpg")
+    private String thumbnailUrl;
+
+    @Schema(description = "시리즈에 포함될 칼럼 ID 목록", example = "[1, 2, 3]")
+    @NotEmpty(message = "최소 하나 이상의 칼럼 ID가 필요합니다.")
+    private List<Long> columnIds;
+}
+

--- a/src/main/java/com/newbit/column/dto/response/CreateSeriesResponseDto.java
+++ b/src/main/java/com/newbit/column/dto/response/CreateSeriesResponseDto.java
@@ -1,0 +1,15 @@
+package com.newbit.column.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "시리즈 생성 응답 DTO")
+public class CreateSeriesResponseDto {
+
+    @Schema(description = "생성된 시리즈 ID", example = "1")
+    private Long seriesId;
+}
+

--- a/src/main/java/com/newbit/column/mapper/SeriesMapper.java
+++ b/src/main/java/com/newbit/column/mapper/SeriesMapper.java
@@ -1,0 +1,25 @@
+package com.newbit.column.mapper;
+
+import com.newbit.column.dto.request.CreateSeriesRequestDto;
+import com.newbit.column.dto.response.CreateSeriesResponseDto;
+import com.newbit.column.domain.Series;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SeriesMapper {
+
+    public Series toSeries(CreateSeriesRequestDto dto) {
+        return Series.builder()
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .thumbnailUrl(dto.getThumbnailUrl())
+                .build();
+    }
+
+    public CreateSeriesResponseDto toCreateSeriesResponseDto(Series series) {
+        return CreateSeriesResponseDto.builder()
+                .seriesId(series.getSeriesId())
+                .build();
+    }
+}
+

--- a/src/main/java/com/newbit/column/repository/SeriesRepository.java
+++ b/src/main/java/com/newbit/column/repository/SeriesRepository.java
@@ -1,0 +1,7 @@
+package com.newbit.column.repository;
+
+import com.newbit.column.domain.Series;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+}

--- a/src/main/java/com/newbit/column/service/SeriesService.java
+++ b/src/main/java/com/newbit/column/service/SeriesService.java
@@ -1,0 +1,68 @@
+package com.newbit.column.service;
+
+import com.newbit.column.domain.Column;
+import com.newbit.column.repository.ColumnRepository;
+import com.newbit.column.dto.request.CreateSeriesRequestDto;
+import com.newbit.column.dto.response.CreateSeriesResponseDto;
+import com.newbit.column.domain.Series;
+import com.newbit.column.mapper.SeriesMapper;
+import com.newbit.column.repository.SeriesRepository;
+import com.newbit.user.entity.Mentor;
+import com.newbit.user.service.MentorService;
+import com.newbit.common.exception.BusinessException;
+import com.newbit.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SeriesService {
+
+    private final SeriesRepository seriesRepository;
+    private final ColumnRepository columnRepository;
+    private final MentorService mentorService;
+    private final SeriesMapper seriesMapper;
+
+    public CreateSeriesResponseDto createSeries(CreateSeriesRequestDto dto, Long userId) {
+        // 1. 유저 → 멘토 엔티티 조회
+        Mentor mentor = mentorService.getMentorEntityByUserId(userId);
+
+        // 2. 빈 칼럼 리스트 방지
+        if (dto.getColumnIds() == null || dto.getColumnIds().isEmpty()) {
+            throw new BusinessException(ErrorCode.SERIES_CREATION_REQUIRES_COLUMNS);
+        }
+
+        // 3. 칼럼 ID에 해당하는 Column 리스트 조회
+        List<Column> columns = columnRepository.findAllById(dto.getColumnIds());
+
+        if (columns.size() != dto.getColumnIds().size()) {
+            throw new BusinessException(ErrorCode.COLUMN_NOT_FOUND);
+        }
+
+        // 4. 본인 칼럼인지 확인
+        boolean hasInvalidOwner = columns.stream()
+                .anyMatch(column -> !column.getMentor().getMentorId().equals(mentor.getMentorId()));
+        if (hasInvalidOwner) {
+            throw new BusinessException(ErrorCode.COLUMN_NOT_OWNED);
+        }
+
+        // 5. 이미 시리즈에 포함된 칼럼인지 확인
+        boolean hasAlreadyGrouped = columns.stream().anyMatch(column -> column.getSeries() != null);
+        if (hasAlreadyGrouped) {
+            throw new BusinessException(ErrorCode.COLUMN_ALREADY_IN_SERIES);
+        }
+
+        // 6. 시리즈 저장
+        Series series = seriesRepository.save(seriesMapper.toSeries(dto));
+
+        // 7. 각 칼럼에 시리즈 연결
+        columns.forEach(column -> column.updateSeries(series));
+        columnRepository.saveAll(columns);
+
+        // 8. 응답 반환
+        return seriesMapper.toCreateSeriesResponseDto(series);
+    }
+}
+

--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -33,8 +33,6 @@ public enum ErrorCode {
     INVALID_PASSWORD_FORMAT("20009", "비밀번호 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_CURRENT_PASSWORD("20010", "비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
-
-
     /*--------------- 커피챗 오류 ------------------*/
     COFFEECHAT_NOT_FOUND("70001", "해당 커피챗을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     REQUEST_TIME_NOT_FOUND("70002", "해당 커피챗 시간 요청내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
@@ -46,7 +44,6 @@ public enum ErrorCode {
     COLUMN_ALREADY_PURCHASED("60000", "이미 구매한 칼럼입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_DIAMOND("60001", "보유한 다이아가 부족합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     COLUMN_FREE_CANNOT_PURCHASE("60002", "무료 칼럼은 구매할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    COLUMN_NOT_FOUND("60003", "해당 칼럼을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     COLUMN_NOT_PURCHASED("60004", "칼럼을 구매한 사용자만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
     COFFEECHAT_NOT_PURCHASABLE("60005", "커피챗이 구매할 수 없는 상태입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_MENTOR("60005", "이미 멘토인 회원입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
@@ -56,6 +53,14 @@ public enum ErrorCode {
     INVALID_TIP_AMOUNT("60009", "잘못된 팁 제공량 입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     COFFEECHAT_PURCHASE_NOT_ALLOWED("60010", "본인의 커피챗만 구매 가능합니다.", HttpStatus.FORBIDDEN),
 
+    /*--------------- 칼럼/시리즈 오류 ------------------*/
+    // 칼럼 오류
+    COLUMN_NOT_FOUND("60003", "해당 칼럼을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COLUMN_NOT_OWNED("60011", "해당 칼럼에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    COLUMN_ALREADY_IN_SERIES("60012", "해당 칼럼은 이미 다른 시리즈에 속해있습니다.", HttpStatus.BAD_REQUEST),
+
+    // 시리즈 오류
+    SERIES_CREATION_REQUIRES_COLUMNS("30000", "시리즈는 최소 1개 이상의 칼럼으로 생성되어야 합니다.", HttpStatus.BAD_REQUEST),
 
     /*--------------- JWT 토큰 오류 ------------------*/
     JWT_INVALID("80001", "유효하지 않은 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/test/java/com/newbit/column/service/SeriesServiceTest.java
+++ b/src/test/java/com/newbit/column/service/SeriesServiceTest.java
@@ -1,0 +1,86 @@
+package com.newbit.column.service;
+
+import com.newbit.column.domain.Column;
+import com.newbit.column.domain.Series;
+import com.newbit.column.dto.request.CreateSeriesRequestDto;
+import com.newbit.column.dto.response.CreateSeriesResponseDto;
+import com.newbit.column.mapper.SeriesMapper;
+import com.newbit.column.repository.ColumnRepository;
+import com.newbit.column.repository.SeriesRepository;
+import com.newbit.user.entity.Mentor;
+import com.newbit.user.service.MentorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class SeriesServiceTest {
+
+    @Mock
+    private SeriesRepository seriesRepository;
+
+    @Mock
+    private ColumnRepository columnRepository;
+
+    @Mock
+    private MentorService mentorService;
+
+    @Mock
+    private SeriesMapper seriesMapper;
+
+    @InjectMocks
+    private SeriesService seriesService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("시리즈 생성 - 성공")
+    @Test
+    void createSeries_success() {
+        // given
+        Long userId = 1L;
+        Long mentorId = 10L;
+
+        CreateSeriesRequestDto dto = new CreateSeriesRequestDto(
+                "시리즈 제목",
+                "시리즈 설명",
+                "https://example.com/img.jpg",
+                List.of(1L, 2L)
+        );
+
+        Mentor mentor = Mentor.builder().mentorId(mentorId).build();
+
+        Column column1 = Column.builder().columnId(1L).mentor(mentor).build();
+        Column column2 = Column.builder().columnId(2L).mentor(mentor).build();
+        List<Column> columns = List.of(column1, column2);
+
+        Series series = Series.builder().seriesId(100L).title(dto.getTitle()).build();
+        CreateSeriesResponseDto responseDto = CreateSeriesResponseDto.builder().seriesId(100L).build();
+
+        when(mentorService.getMentorEntityByUserId(userId)).thenReturn(mentor);
+        when(columnRepository.findAllById(dto.getColumnIds())).thenReturn(columns);
+        when(seriesMapper.toSeries(dto)).thenReturn(series);
+        when(seriesRepository.save(series)).thenReturn(series);
+        when(seriesMapper.toCreateSeriesResponseDto(series)).thenReturn(responseDto);
+
+        // when
+        CreateSeriesResponseDto result = seriesService.createSeries(dto, userId);
+
+        // then
+        assertThat(result.getSeriesId()).isEqualTo(100L);
+        verify(mentorService).getMentorEntityByUserId(userId);
+        verify(columnRepository).findAllById(dto.getColumnIds());
+        verify(seriesRepository).save(series);
+        verify(columnRepository).saveAll(columns);
+        verify(seriesMapper).toCreateSeriesResponseDto(series);
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
Nbt 87 be 시리즈 생성 기능 구현	

### 🪐 작업 내용
- 기존 칼럼들을 묶어 하나의 시리즈로 등록할 수 있는 시리즈 생성 기능 추가

- 제약 조건

  - 최소 1개 이상의 칼럼을 포함해야 함

  - 해당 칼럼들은 본인의 칼럼이어야 함

  - 이미 시리즈에 포함된 칼럼은 추가할 수 없음

  - 시리즈 생성 시, 각 칼럼에 시리즈 연관관계 설정 (column.updateSeries(series) 호출)