### PR TITLE
Nbt 76 be 멘티구매확정 기능 구현

### DIFF
--- a/src/main/java/com/newbit/coffeechat/command/application/controller/CoffeechatCommandController.java
+++ b/src/main/java/com/newbit/coffeechat/command/application/controller/CoffeechatCommandController.java
@@ -93,4 +93,19 @@ public class CoffeechatCommandController {
         return ResponseEntity
                 .ok(ApiResponse.success(null));
     }
+
+    @Operation(
+            summary = "커피챗 구매확정",
+            description = "멘티가 커피챗 구매확정합니다."
+    )
+    @PutMapping("/confirm-purchase/{coffeechatId}")
+    public ResponseEntity<ApiResponse<Void>> confirmPurchaseCoffeechat(
+            @PathVariable Long coffeechatId
+    ) {
+
+        coffeechatCommandService.confirmPurchaseCoffeechat(coffeechatId);
+
+        return ResponseEntity
+                .ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
+++ b/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
@@ -11,7 +11,7 @@ import com.newbit.coffeechat.query.service.CoffeechatQueryService;
 import com.newbit.coffeechat.query.dto.response.ProgressStatus;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
-import com.newbit.purchase.command.application.service.PurchaseCommandService;
+import com.newbit.purchase.command.application.service.SaleCommandService;
 import com.newbit.user.dto.response.MentorDTO;
 import com.newbit.user.service.MentorService;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class CoffeechatCommandService {
     private final CoffeechatQueryService coffeechatQueryService;
     private final RequestTimeRepository requestTimeRepository;
     private final MentorService mentorService;
-    private final PurchaseCommandService purchaseCommandService;
+    private final SaleCommandService saleCommandService;
 
     /**
      * 한두 번만 사용하는 간단한 조회여서 과도한 추상화를 피하기 위해
@@ -152,6 +152,6 @@ public class CoffeechatCommandService {
         MentorDTO mentorDTO = mentorService.getMentorInfo(coffeechat.getMentorId());
 
         // 4. 정산내역에 추가하기
-        purchaseCommandService.addSaleHistory(coffeechat.getMentorId(), mentorDTO.getPrice(), coffeechatId);
+        saleCommandService.addSaleHistory(coffeechat.getMentorId(), mentorDTO.getPrice(), coffeechatId);
     }
 }

--- a/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
+++ b/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
@@ -152,6 +152,7 @@ public class CoffeechatCommandService {
         MentorDTO mentorDTO = mentorService.getMentorInfo(coffeechat.getMentorId());
 
         // 4. 정산내역에 추가하기
-        saleCommandService.addSaleHistory(coffeechat.getMentorId(), mentorDTO.getPrice(), coffeechatId);
+        int totalQuantity = mentorDTO.getPrice() * coffeechat.getPurchaseQuantity();
+        saleCommandService.addSaleHistory(coffeechat.getMentorId(), totalQuantity, coffeechatId);
     }
 }

--- a/src/main/java/com/newbit/coffeechat/command/domain/aggregate/Coffeechat.java
+++ b/src/main/java/com/newbit/coffeechat/command/domain/aggregate/Coffeechat.java
@@ -83,4 +83,8 @@ public class Coffeechat {
         progressStatus = ProgressStatus.COMPLETE;
         saleConfirmedAt = LocalDateTime.now();
     }
+
+    public void confirmPurchaseSchedule() {
+        purchaseConfirmedAt = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
### 🛰️ Issue
	close #64 

### 🪐 작업 내용
Nbt 76 be 멘티구매확정 기능 구현
구매도매인의 판매확정 서비스와 연결

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] 단위테스트 
- [x] swagger
- [x] postman
