### PR TITLE
Feat 댓글 작성 시 인증된 사용자만 가능하도록 기능 구현

### DIFF
--- a/src/main/java/com/newbit/post/controller/CommentController.java
+++ b/src/main/java/com/newbit/post/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.newbit.post.controller;
 
+import com.newbit.auth.model.CustomUser;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.service.CommentService;
@@ -7,6 +8,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,15 +21,18 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping
     @Operation(summary = "댓글 등록", description = "게시글에 댓글을 등록합니다.")
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable Long postId,
-            @RequestBody @Valid CommentCreateRequest request
+            @RequestBody @Valid CommentCreateRequest request,
+            @AuthenticationPrincipal CustomUser user
     ) {
-        CommentResponse response = commentService.createComment(postId, request);
+        CommentResponse response = commentService.createComment(postId, request, user);
         return ResponseEntity.ok(response);
     }
+
 
     @GetMapping
     @Operation(summary = "댓글 조회", description = "게시글에 달린 댓글 목록을 조회합니다.")

--- a/src/main/java/com/newbit/post/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/newbit/post/dto/request/CommentCreateRequest.java
@@ -13,10 +13,4 @@ public class CommentCreateRequest {
 
     @NotBlank
     private String content;
-
-    @NotNull
-    private Long userId;
-
-    @NotNull
-    private Long postId;
 }

--- a/src/main/java/com/newbit/post/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/newbit/post/dto/request/CommentCreateRequest.java
@@ -1,7 +1,6 @@
 package com.newbit.post.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter

--- a/src/main/java/com/newbit/post/service/CommentService.java
+++ b/src/main/java/com/newbit/post/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.newbit.post.service;
 
+import com.newbit.auth.model.CustomUser;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.entity.Comment;
@@ -23,19 +24,19 @@ public class CommentService {
     private final PointTransactionCommandService pointTransactionCommandService;
 
     @Transactional
-    public CommentResponse createComment(Long postId, CommentCreateRequest request) {
+    public CommentResponse createComment(Long postId, CommentCreateRequest request, CustomUser user) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
 
         Comment comment = Comment.builder()
                 .content(request.getContent())
-                .userId(request.getUserId())
+                .userId(user.getUserId()) // 인증 사용자 ID 사용
                 .reportCount(0)
                 .post(post)
                 .build();
 
         commentRepository.save(comment);
-        pointTransactionCommandService.givePointByType(request.getUserId(), "댓글 적립", comment.getId());
+        pointTransactionCommandService.givePointByType(user.getUserId(), "댓글 적립", comment.getId());
         return new CommentResponse(comment);
     }
 

--- a/src/test/java/com/newbit/post/service/CommentServiceTest.java
+++ b/src/test/java/com/newbit/post/service/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package com.newbit.post.service;
 
+import com.newbit.auth.model.CustomUser;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.entity.Comment;
@@ -9,6 +10,7 @@ import com.newbit.post.repository.PostRepository;
 import com.newbit.purchase.command.application.service.PointTransactionCommandService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -78,8 +80,12 @@ class CommentServiceTest {
 
         CommentCreateRequest request = CommentCreateRequest.builder()
                 .content("댓글 내용입니다.")
+                .build();
+
+        CustomUser user = CustomUser.builder()
                 .userId(1L)
-                .postId(postId)
+                .email("user@example.com")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
                 .build();
 
         Post mockPost = Post.builder()
@@ -94,11 +100,13 @@ class CommentServiceTest {
         when(commentRepository.save(any(Comment.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        CommentResponse response = commentService.createComment(postId, request);
+        CommentResponse response = commentService.createComment(postId, request, user);
 
         assertThat(response.getContent()).isEqualTo("댓글 내용입니다.");
         verify(commentRepository, times(1)).save(any(Comment.class));
     }
+
+
 
     @Test
     void 댓글_삭제_성공() {


### PR DESCRIPTION
### 🪐 작업 내용
CommentController에 @PreAuthorize("isAuthenticated()") 적용
@AuthenticationPrincipal CustomUser를 통해 로그인한 사용자 정보 전달
CommentService#createComment() 메서드 시그니처 수정: userId → CustomUser 사용
댓글 작성 시 작성자 정보(userId)를 CustomUser에서 추출
테스트 코드 댓글_등록_성공() 수정하여 인증 사용자 기반으로 동작 확인

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] Swagger API 테스트 
- [x] 단위 테스트
