### PR TITLE
[BE] NBT-150 알림 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -5,6 +5,8 @@ import com.newbit.common.dto.ApiResponse;
 import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
 import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.notification.command.infrastructure.SseEmitterRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -16,6 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.util.UUID;
 
+@Tag(name = "알림 API", description = "알림 연결, 발송 API")
 @RestController
 @RequestMapping("/api/v1/notification")
 @RequiredArgsConstructor
@@ -23,6 +26,7 @@ public class NotificationCommandController {
 
     private final SseEmitterRepository sseEmitterRepository;
     private final NotificationCommandService notificationCommandService;
+
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@AuthenticationPrincipal CustomUser customUser) {
@@ -46,6 +50,7 @@ public class NotificationCommandController {
         return emitter;
     }
 
+    @Operation(summary = "알림 전송", description = "특정 사용자에게 알림을 전송합니다.")
     @PostMapping("/send")
     public ResponseEntity<ApiResponse<Void>> sendNotification(
             @Valid @RequestBody NotificationSendRequest request

--- a/src/main/java/com/newbit/notification/command/application/dto/request/NotificationSendRequest.java
+++ b/src/main/java/com/newbit/notification/command/application/dto/request/NotificationSendRequest.java
@@ -1,20 +1,26 @@
 package com.newbit.notification.command.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+
 @Getter
 @AllArgsConstructor
+@Schema(description = "알림 전송 요청 DTO")
 public class NotificationSendRequest {
 
     @NotNull
+    @Schema(description = "알림을 받을 유저 ID", example = "1")
     private Long userId;
 
     @NotNull
+    @Schema(description = "알림 유형 ID", example = "2")
     private Long notificationTypeId;
 
     @NotBlank
+    @Schema(description = "알림 내용", example = "새로운 커피챗 신청이 도착했습니다.")
     private String content;
 }

--- a/src/main/java/com/newbit/notification/command/application/dto/response/NotificationSendResponse.java
+++ b/src/main/java/com/newbit/notification/command/application/dto/response/NotificationSendResponse.java
@@ -1,0 +1,25 @@
+package com.newbit.notification.command.application.dto.response;
+
+import com.newbit.notification.command.domain.aggregate.Notification;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public class NotificationSendResponse {
+    private Long notificationId;
+    private String content;
+    private String typeName;
+    private Boolean isRead;
+    private LocalDateTime createdAt;
+
+    public static NotificationSendResponse from(Notification notification) {
+        return NotificationSendResponse.builder()
+                .notificationId(notification.getNotificationId())
+                .content(notification.getContent())
+                .typeName(notification.getNotificationType().getName())
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/newbit/notification/command/application/dto/response/NotificationSendResponse.java
+++ b/src/main/java/com/newbit/notification/command/application/dto/response/NotificationSendResponse.java
@@ -1,16 +1,30 @@
 package com.newbit.notification.command.application.dto.response;
 
 import com.newbit.notification.command.domain.aggregate.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
+@Schema(description = "알림 전송 응답 DTO")
 public class NotificationSendResponse {
+
+    @Schema(description = "알림 ID", example = "101")
     private Long notificationId;
+
+    @Schema(description = "알림 내용", example = "멘토가 커피챗 요청을 수락했습니다.")
     private String content;
+
+    @Schema(description = "알림 유형 이름", example = "COFFEECHAT_ACCEPTED")
     private String typeName;
+
+    @Schema(description = "읽음 여부", example = "false")
     private Boolean isRead;
+
+    @Schema(description = "알림 생성일시", example = "2025-04-11T18:45:00")
     private LocalDateTime createdAt;
 
     public static NotificationSendResponse from(Notification notification) {

--- a/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
+++ b/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
@@ -2,7 +2,7 @@ package com.newbit.notification.command.application.service;
 
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
-import com.newbit.notification.command.application.dto.response.NotificationResponse;
+import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
 import com.newbit.notification.command.domain.aggregate.Notification;
 import com.newbit.notification.command.domain.aggregate.NotificationType;
 import com.newbit.notification.command.domain.repository.NotificationRepository;
@@ -36,7 +36,7 @@ public class NotificationCommandService {
         notificationRepository.save(notification);
 
         // 3. 실시간 알림 전송
-        NotificationResponse response = NotificationResponse.from(notification);
+        NotificationSendResponse response = NotificationSendResponse.from(notification);
         sseEmitterRepository.send(request.getUserId(), response);
     }
 }

--- a/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
@@ -3,5 +3,8 @@ package com.newbit.notification.command.domain.repository;
 import com.newbit.notification.command.domain.aggregate.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    Collection<Object> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/newbit/notification/command/infrastructure/SseEmitterRepository.java
+++ b/src/main/java/com/newbit/notification/command/infrastructure/SseEmitterRepository.java
@@ -1,6 +1,6 @@
 package com.newbit.notification.command.infrastructure;
 
-import com.newbit.notification.command.application.dto.response.NotificationResponse;
+import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -31,7 +31,7 @@ public class SseEmitterRepository {
         userEmitterMap.forEach((userId, emitterIds) -> emitterIds.remove(emitterId));
     }
 
-    public void send(Long userId, NotificationResponse response) {
+    public void send(Long userId, NotificationSendResponse response) {
         List<String> emitterIds = userEmitterMap.getOrDefault(userId, new ArrayList<>());
 
         for (String emitterId : emitterIds) {

--- a/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
+++ b/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
@@ -1,0 +1,37 @@
+package com.newbit.notification.query.controller;
+
+
+import com.newbit.auth.model.CustomUser;
+import com.newbit.common.dto.ApiResponse;
+import com.newbit.notification.query.dto.NotificationListResponse;
+import com.newbit.notification.query.service.NotificationQueryService;
+import com.newbit.purchase.query.dto.request.HistoryRequest;
+import com.newbit.purchase.query.dto.response.ColumnPurchaseHistoryListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림 API", description = "알림 목록 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationQueryController {
+
+    NotificationQueryService notificationQueryService;
+
+    @Operation(summary = "알림 목록 조회", description = "특정 유저의 알림 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<NotificationListResponse>> getNotificationList(
+            @AuthenticationPrincipal CustomUser customUser) {
+        NotificationListResponse response = notificationQueryService.getNotifications(customUser.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
+++ b/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
@@ -1,37 +1,31 @@
 package com.newbit.notification.query.controller;
 
-
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.dto.ApiResponse;
-import com.newbit.notification.query.dto.NotificationListResponse;
+import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
+import com.newbit.notification.query.dto.NotificationResponse;
 import com.newbit.notification.query.service.NotificationQueryService;
-import com.newbit.purchase.query.dto.request.HistoryRequest;
-import com.newbit.purchase.query.dto.response.ColumnPurchaseHistoryListResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "알림 API", description = "알림 목록 조회 API")
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/v1/notification")
+@RequiredArgsConstructor
 public class NotificationQueryController {
 
-    NotificationQueryService notificationQueryService;
+    private final NotificationQueryService notificationQueryService;
 
-    @Operation(summary = "알림 목록 조회", description = "특정 유저의 알림 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<NotificationListResponse>> getNotificationList(
-            @AuthenticationPrincipal CustomUser customUser) {
-        NotificationListResponse response = notificationQueryService.getNotifications(customUser.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success(response));
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> getNotificationList(
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        List<NotificationResponse> notifications = notificationQueryService.getNotifications(customUser.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(notifications));
     }
-
 }

--- a/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
+++ b/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
@@ -5,6 +5,7 @@ import com.newbit.common.dto.ApiResponse;
 import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
 import com.newbit.notification.query.dto.NotificationResponse;
 import com.newbit.notification.query.service.NotificationQueryService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,7 @@ public class NotificationQueryController {
 
     private final NotificationQueryService notificationQueryService;
 
+    @Operation(summary = "알림 목록 조회", description = "해당 유저의 알림 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<List<NotificationResponse>>> getNotificationList(
             @AuthenticationPrincipal CustomUser customUser

--- a/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
+++ b/src/main/java/com/newbit/notification/query/controller/NotificationQueryController.java
@@ -2,7 +2,6 @@ package com.newbit.notification.query.controller;
 
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.dto.ApiResponse;
-import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
 import com.newbit.notification.query.dto.NotificationResponse;
 import com.newbit.notification.query.service.NotificationQueryService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/newbit/notification/query/dto/NotificationResponse.java
+++ b/src/main/java/com/newbit/notification/query/dto/NotificationResponse.java
@@ -1,17 +1,12 @@
-package com.newbit.notification.command.application.dto.response;
+package com.newbit.notification.query.dto;
 
 import com.newbit.notification.command.domain.aggregate.Notification;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Getter
 @Builder
-@AllArgsConstructor
 public class NotificationResponse {
-
     private Long notificationId;
     private String content;
     private String typeName;

--- a/src/main/java/com/newbit/notification/query/dto/NotificationResponse.java
+++ b/src/main/java/com/newbit/notification/query/dto/NotificationResponse.java
@@ -1,14 +1,26 @@
 package com.newbit.notification.query.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
+@Schema(description = "알림 응답 DTO")
 public class NotificationResponse {
+
+    @Schema(description = "알림 ID", example = "1")
     private Long notificationId;
+
+    @Schema(description = "알림 내용", example = "새로운 댓글이 달렸습니다.")
     private String content;
+
+    @Schema(description = "알림 유형 이름", example = "COMMENT")
     private String typeName;
+
+    @Schema(description = "읽음 여부", example = "false")
     private Boolean isRead;
+
+    @Schema(description = "알림 생성일시", example = "2025-04-11T17:35:20")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/newbit/notification/query/dto/NotificationResponse.java
+++ b/src/main/java/com/newbit/notification/query/dto/NotificationResponse.java
@@ -1,25 +1,14 @@
 package com.newbit.notification.query.dto;
 
-import com.newbit.notification.command.domain.aggregate.Notification;
-import lombok.Builder;
+import lombok.Data;
 
 import java.time.LocalDateTime;
 
-@Builder
+@Data
 public class NotificationResponse {
     private Long notificationId;
     private String content;
     private String typeName;
     private Boolean isRead;
     private LocalDateTime createdAt;
-
-    public static NotificationResponse from(Notification notification) {
-        return NotificationResponse.builder()
-                .notificationId(notification.getNotificationId())
-                .content(notification.getContent())
-                .typeName(notification.getNotificationType().getName())
-                .isRead(notification.getIsRead())
-                .createdAt(notification.getCreatedAt())
-                .build();
-    }
 }

--- a/src/main/java/com/newbit/notification/query/mapper/NotificationQueryMapper.java
+++ b/src/main/java/com/newbit/notification/query/mapper/NotificationQueryMapper.java
@@ -1,0 +1,11 @@
+package com.newbit.notification.query.mapper;
+
+import com.newbit.notification.query.dto.NotificationResponse;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface NotificationQueryMapper {
+    List<NotificationResponse> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/newbit/notification/query/repository/NotificationRepository.java
+++ b/src/main/java/com/newbit/notification/query/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.newbit.notification.query.repository;
+
+import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<NotificationSendResponse, Long> {
+}

--- a/src/main/java/com/newbit/notification/query/repository/NotificationRepository.java
+++ b/src/main/java/com/newbit/notification/query/repository/NotificationRepository.java
@@ -1,7 +1,0 @@
-package com.newbit.notification.query.repository;
-
-import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface NotificationRepository extends JpaRepository<NotificationSendResponse, Long> {
-}

--- a/src/main/java/com/newbit/notification/query/service/NotificationQueryService.java
+++ b/src/main/java/com/newbit/notification/query/service/NotificationQueryService.java
@@ -1,6 +1,7 @@
 package com.newbit.notification.query.service;
-import com.newbit.notification.command.domain.repository.NotificationRepository;
+
 import com.newbit.notification.query.dto.NotificationResponse;
+import com.newbit.notification.query.mapper.NotificationQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,11 +11,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationQueryService {
 
-    private final NotificationRepository notificationRepository;
+    private final NotificationQueryMapper notificationQueryMapper;
 
     public List<NotificationResponse> getNotifications(Long userId) {
-        return notificationRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
-                .map(NotificationResponse::from)
-                .toList();
+        return notificationQueryMapper.findAllByUserId(userId);
     }
 }

--- a/src/main/java/com/newbit/notification/query/service/NotificationQueryService.java
+++ b/src/main/java/com/newbit/notification/query/service/NotificationQueryService.java
@@ -1,0 +1,20 @@
+package com.newbit.notification.query.service;
+import com.newbit.notification.command.domain.repository.NotificationRepository;
+import com.newbit.notification.query.dto.NotificationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryService {
+
+    private final NotificationRepository notificationRepository;
+
+    public List<NotificationResponse> getNotifications(Long userId) {
+        return notificationRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+}

--- a/src/main/resources/mappers/notification/NotificationMapper.xml
+++ b/src/main/resources/mappers/notification/NotificationMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.newbit.notification.query.mapper.NotificationQueryMapper">
+
+    <select id="findAllByUserId" resultType="com.newbit.notification.query.dto.NotificationResponse">
+        SELECT
+        n.notification_id AS notificationId,
+        n.content,
+        n.is_read AS isRead,
+        n.created_at AS createdAt,
+        nt.notification_type_name AS typeName
+        FROM notification n
+        JOIN notification_type nt ON n.notification_type_id = nt.notification_type_id
+        WHERE n.user_id = #{userId}
+        ORDER BY n.created_at DESC
+    </select>
+
+</mapper>

--- a/src/test/java/com/newbit/notification/command/application/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/newbit/notification/command/application/service/NotificationCommandServiceTest.java
@@ -3,7 +3,7 @@ package com.newbit.notification.command.application.service;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
 import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
-import com.newbit.notification.command.application.dto.response.NotificationResponse;
+import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
 import com.newbit.notification.command.domain.aggregate.Notification;
 import com.newbit.notification.command.domain.aggregate.NotificationType;
 import com.newbit.notification.command.domain.repository.NotificationRepository;
@@ -65,7 +65,7 @@ class NotificationCommandServiceTest {
         // then
         verify(notificationTypeRepository, times(1)).findById(typeId);
         verify(notificationRepository, times(1)).save(any(Notification.class));
-        verify(sseEmitterRepository, times(1)).send(eq(userId), any(NotificationResponse.class));
+        verify(sseEmitterRepository, times(1)).send(eq(userId), any(NotificationSendResponse.class));
     }
 
     @Test

--- a/src/test/java/com/newbit/notification/query/service/NotificationQueryServiceTest.java
+++ b/src/test/java/com/newbit/notification/query/service/NotificationQueryServiceTest.java
@@ -1,0 +1,49 @@
+package com.newbit.notification.query.service;
+
+import com.newbit.notification.query.dto.NotificationResponse;
+import com.newbit.notification.query.mapper.NotificationQueryMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class NotificationQueryServiceTest {
+
+    @InjectMocks
+    private NotificationQueryService notificationQueryService;
+
+    @Mock
+    private NotificationQueryMapper notificationQueryMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getNotifications_returnsListOfNotifications() {
+        // Given
+        Long userId = 1L;
+        NotificationResponse mockResponse = new NotificationResponse();
+        mockResponse.setNotificationId(10L);
+        mockResponse.setContent("새 댓글이 달렸습니다.");
+        mockResponse.setTypeName("COMMENT");
+        mockResponse.setIsRead(false);
+        mockResponse.setCreatedAt(LocalDateTime.now());
+
+        when(notificationQueryMapper.findAllByUserId(userId)).thenReturn(List.of(mockResponse));
+
+        // When
+        List<NotificationResponse> result = notificationQueryService.getNotifications(userId);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getNotificationId()).isEqualTo(10L);
+        verify(notificationQueryMapper, times(1)).findAllByUserId(userId);
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
NBT-150 알림 목록 조회 기능 구현(close #167)

### 🪐 작업 내용
- 특정 사용자의 알림 목록을 최신순(createdAt DESC)으로 조회하는 기능 구현
- notification, notification_type 테이블을 조인하여 알림 유형 이름까지 함께 조회
- NotificationQueryService + NotificationQueryMapper + MyBatis XML 매핑 방식으로 구현
- NotificationResponse DTO 정의
- 알림 ID, 내용, 읽음 여부, 생성일시, 알림 유형명 포함
- GET /api/v1/notification 엔드포인트 구현

### ✅ Check List (선택)
- [x] 단위 테스트 코드 작성
- [x] Postman, Swagger API 테스트 완료
