### PR TITLE
[BE] NBT-151 알림 읽음 처리 기능 구현

### DIFF
--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -70,7 +70,8 @@ public enum ErrorCode {
 
     /*----------------알림-------------------------*/
     NOTIFICATION_TYPE_NOT_FOUND("90001", "잘못된 알림 유형 입니다.", HttpStatus.NOT_FOUND),
-    NOTIFICATION_NOT_FOUND("90002", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    NOTIFICATION_NOT_FOUND("90002", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_ACCESS("90003", "인증되지 않은 접근", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -69,7 +69,8 @@ public enum ErrorCode {
     JWT_CLAIMS_EMPTY("80004", "JWT 클레임이 비어 있습니다.", HttpStatus.BAD_REQUEST),
 
     /*----------------알림-------------------------*/
-    NOTIFICATION_TYPE_NOT_FOUND("90001", "잘못된 알림 유형 입니다.", HttpStatus.NOT_FOUND);
+    NOTIFICATION_TYPE_NOT_FOUND("90001", "잘못된 알림 유형 입니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_NOT_FOUND("90002", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -28,7 +28,6 @@ public class NotificationCommandController {
 
     private final SseEmitterRepository sseEmitterRepository;
     private final NotificationCommandService notificationCommandService;
-    private final NotificationRepository notificationRepository;
 
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -2,11 +2,8 @@ package com.newbit.notification.command.application.controller;
 
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.dto.ApiResponse;
-import com.newbit.common.exception.BusinessException;
-import com.newbit.common.exception.ErrorCode;
 import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
 import com.newbit.notification.command.application.service.NotificationCommandService;
-import com.newbit.notification.command.domain.aggregate.Notification;
 import com.newbit.notification.command.domain.repository.NotificationRepository;
 import com.newbit.notification.command.infrastructure.SseEmitterRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 

--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -75,4 +75,13 @@ public class NotificationCommandController {
         notificationCommandService.markAsRead(user.getUserId(), notificationId);
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/read-all")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> markAllAsRead(@AuthenticationPrincipal CustomUser user) {
+        notificationCommandService.markAllAsRead(user.getUserId());
+        return ResponseEntity.ok().build();
+    }
+
+
 }

--- a/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
+++ b/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
@@ -1,6 +1,5 @@
 package com.newbit.notification.command.application.service;
 
-import com.newbit.auth.model.CustomUser;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
 import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
@@ -11,13 +10,10 @@ import com.newbit.notification.command.domain.repository.NotificationTypeReposit
 import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
 import com.newbit.notification.command.infrastructure.SseEmitterRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+
 
 @Service
 @RequiredArgsConstructor
@@ -60,4 +56,8 @@ public class NotificationCommandService {
         notification.markAsRead(); // 내부에서 isRead = true 처리
     }
 
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        notificationRepository.markAllAsReadByUserId(userId);
+    }
 }

--- a/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
+++ b/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
@@ -1,5 +1,6 @@
 package com.newbit.notification.command.application.service;
 
+import com.newbit.auth.model.CustomUser;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
 import com.newbit.notification.command.application.dto.response.NotificationSendResponse;
@@ -10,8 +11,13 @@ import com.newbit.notification.command.domain.repository.NotificationTypeReposit
 import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
 import com.newbit.notification.command.infrastructure.SseEmitterRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Service
 @RequiredArgsConstructor
@@ -39,4 +45,15 @@ public class NotificationCommandService {
         NotificationSendResponse response = NotificationSendResponse.from(notification);
         sseEmitterRepository.send(request.getUserId(), response);
     }
+
+
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        notification.markAsRead(); // 내부에서 isRead = true 처리
+    }
+
 }

--- a/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
+++ b/src/main/java/com/newbit/notification/command/application/service/NotificationCommandService.java
@@ -53,6 +53,10 @@ public class NotificationCommandService {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
+        if (!notification.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
         notification.markAsRead(); // 내부에서 isRead = true 처리
     }
 

--- a/src/main/java/com/newbit/notification/command/domain/aggregate/Notification.java
+++ b/src/main/java/com/newbit/notification/command/domain/aggregate/Notification.java
@@ -42,4 +42,8 @@ public class Notification {
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/newbit/notification/command/domain/aggregate/NotificationType.java
+++ b/src/main/java/com/newbit/notification/command/domain/aggregate/NotificationType.java
@@ -25,5 +25,7 @@ public class NotificationType {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now();
+
+
 }
 

--- a/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Collection;
-
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")

--- a/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Collection;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Collection<Object> findAllByUserIdOrderByCreatedAtDesc(Long userId);
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")
     void markAllAsReadByUserId(Long userId);

--- a/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/newbit/notification/command/domain/repository/NotificationRepository.java
@@ -2,9 +2,14 @@ package com.newbit.notification.command.domain.repository;
 
 import com.newbit.notification.command.domain.aggregate.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Collection<Object> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")
+    void markAllAsReadByUserId(Long userId);
 }


### PR DESCRIPTION
### 🛰️ Issue
NBT-151 알림 읽음 처리 기능 구현 (close #168)

### 🪐 작업 내용
- notificationId로 특정 알림에 대한 알림 읽음 처리 구현
- 본인의 알림인지 검증하는 로직 추가
- 안읽은 모든 알림에 대해서 읽음처리 구현

### ✅ Check List (선택)
- [x] 단위 테스트 코드 작성
- [x] Postman으로 API 테스트
- [x] Swagger API 명세 작성
