### PR TITLE
feat/Nbt 187 시리즈 삭제 기능 구현

### DIFF
--- a/src/main/java/com/newbit/column/controller/SeriesController.java
+++ b/src/main/java/com/newbit/column/controller/SeriesController.java
@@ -40,4 +40,15 @@ public class SeriesController {
     ) {
         return ApiResponse.success(seriesService.updateSeries(seriesId, dto, customUser.getUserId()));
     }
+
+    @DeleteMapping("/{seriesId}")
+    @Operation(summary = "시리즈 삭제", description = "시리즈를 삭제하고, 연결된 칼럼의 시리즈 정보를 제거합니다.")
+    public ApiResponse<Void> deleteSeries(
+            @PathVariable Long seriesId,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        seriesService.deleteSeries(seriesId, customUser.getUserId());
+        return ApiResponse.success(null);
+    }
+
 }

--- a/src/test/java/com/newbit/column/service/SeriesServiceTest.java
+++ b/src/test/java/com/newbit/column/service/SeriesServiceTest.java
@@ -133,4 +133,34 @@ class SeriesServiceTest {
         assertThat(series.getThumbnailUrl()).isEqualTo("https://example.com/updated.jpg");
     }
 
+    @DisplayName("시리즈 삭제 - 성공")
+    @Test
+    void deleteSeries_success() {
+        // given
+        Long seriesId = 100L;
+        Long userId = 1L;
+        Long mentorId = 10L;
+
+        Mentor mentor = Mentor.builder().mentorId(mentorId).build();
+        Series series = Series.builder().seriesId(seriesId).build();
+
+        Column column1 = Column.builder().columnId(1L).mentor(mentor).series(series).build();
+        Column column2 = Column.builder().columnId(2L).mentor(mentor).series(series).build();
+        List<Column> columns = List.of(column1, column2);
+
+        when(mentorService.getMentorEntityByUserId(userId)).thenReturn(mentor);
+        when(seriesRepository.findById(seriesId)).thenReturn(java.util.Optional.of(series));
+        when(columnRepository.findAllBySeries_SeriesId(seriesId)).thenReturn(columns);
+
+        // when
+        seriesService.deleteSeries(seriesId, userId);
+
+        // then
+        verify(mentorService).getMentorEntityByUserId(userId);
+        verify(seriesRepository).findById(seriesId);
+        verify(columnRepository).findAllBySeries_SeriesId(seriesId);
+        verify(columnRepository).saveAll(anyList());
+        verify(seriesRepository).delete(series);
+    }
+
 }


### PR DESCRIPTION
### 🛰️ Issue
	

### 🪐 작업 내용
1. 시리즈 삭제 기능 구현 (DELETE /api/v1/series/{seriesId})
2. 시리즈에 포함된 칼럼들의 series 참조 해제 처리
3. 본인 소유의 시리즈만 삭제 가능하도록 검증 추가
4. SeriesServiceTest에 시리즈 삭제 성공 테스트 추가
5. 존재하지 않는 시리즈인 경우 → SERIES_NOT_FOUND
6. 본인이 소유하지 않은 칼럼이 포함된 시리즈인 경우 → COLUMN_NOT_OWNED
