### PR TITLE
Nbt 203 be 댓글 삭제 기능 수정 회원 인증

### DIFF
--- a/src/main/java/com/newbit/post/controller/CommentController.java
+++ b/src/main/java/com/newbit/post/controller/CommentController.java
@@ -42,14 +42,17 @@ public class CommentController {
     }
 
 
+    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/{commentId}")
-    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @Operation(summary = "댓글 삭제", description = "회원만 자신이 작성한 댓글을 삭제할 수 있습니다.")
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long postId,
-            @PathVariable Long commentId
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUser user
     ) {
-        commentService.deleteComment(postId, commentId);
+        commentService.deleteComment(postId, commentId, user);
         return ResponseEntity.noContent().build();
     }
+
 
 }

--- a/src/main/java/com/newbit/post/controller/CommentController.java
+++ b/src/main/java/com/newbit/post/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "댓글 API", description = "댓글 등록, 조회, 삭제 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts/{postId}/comments")

--- a/src/main/java/com/newbit/post/service/CommentService.java
+++ b/src/main/java/com/newbit/post/service/CommentService.java
@@ -49,7 +49,7 @@ public class CommentService {
     }
 
     @Transactional
-    public void deleteComment(Long postId, Long commentId) {
+    public void deleteComment(Long postId, Long commentId, CustomUser user) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
 
@@ -57,6 +57,10 @@ public class CommentService {
             throw new IllegalArgumentException("해당 댓글이 존재하지 않거나 게시글과 매칭되지 않습니다.");
         }
 
+
+        if (!comment.getUserId().equals(user.getUserId())) {
+            throw new SecurityException("댓글은 작성자만 삭제할 수 있습니다.");
+        }
         comment.softDelete();
     }
 


### PR DESCRIPTION
### 🛰️ Issue
close #298 	

### 🪐 작업 내용
 - CommentService에 Swagger 태그(@Tag) 추가
 - 인증된 사용자만 댓글을 삭제할 수 있도록 보안 로직 추가
 - 댓글 작성자 본인만 삭제 가능하도록 조건 추가 (userId 일치 여부 검증)
 - CommentService.deleteComment() 메서드에 사용자 인증 및 권한 체크 로직 적용
 - CommentController.deleteComment()에 @PreAuthorize("isAuthenticated()") 및 @AuthenticationPrincipal CustomUser user 파라미터 추가

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] Swagger API 테스트 
- [x] 단위 테스트
