### PR TITLE
Nbt 199 게시글 에러 코드 common 패키지의 공통 에러 양식으로 리팩토링

### DIFF
--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -79,7 +79,23 @@ public enum ErrorCode {
     /*----------------좋아요 관련-------------------*/
     POST_LIKE_NOT_FOUND("100001", "해당 게시글 좋아요를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     COLUMN_LIKE_NOT_FOUND("100002", "해당 칼럼 좋아요를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    LIKE_PROCESSING_ERROR("100003", "좋아요 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    LIKE_PROCESSING_ERROR("100003", "좋아요 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    /*---------------- 게시글 -------------------------*/
+    POST_NOT_FOUND("110000", "해당 게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_TO_UPDATE_POST("110001", "게시글은 작성자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_USER_CAN_CREATE_POST("110002", "게시글은 일반 사용자만 작성할 수 있습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED_TO_DELETE_POST("110003", "게시글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_ADMIN_CAN_CREATE_NOTICE("110004", "공지사항은 관리자만 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_ADMIN_CAN_UPDATE_NOTICE("110005", "공지사항은 관리자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_ADMIN_CAN_DELETE_NOTICE("10006", "공지사항은 관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    NOT_A_NOTICE("110007", "해당 게시글은 공지사항이 아닙니다.", HttpStatus.BAD_REQUEST),
+
+    /*---------------- 댓글 -------------------------*/
+    COMMENT_NOT_FOUND("120000", "해당 댓글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_TO_DELETE_COMMENT("120001", "댓글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED_TO_CREATE_COMMENT("120002", "댓글 작성은 회원만 가능합니다.", HttpStatus.FORBIDDEN),
+    COMMENT_POST_MISMATCH("120003", "해당 댓글은 게시글과 매칭되지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -82,20 +82,20 @@ public enum ErrorCode {
     LIKE_PROCESSING_ERROR("100003", "좋아요 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     /*---------------- 게시글 -------------------------*/
-    POST_NOT_FOUND("110000", "해당 게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    UNAUTHORIZED_TO_UPDATE_POST("110001", "게시글은 작성자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
-    ONLY_USER_CAN_CREATE_POST("110002", "게시글은 일반 사용자만 작성할 수 있습니다.", HttpStatus.FORBIDDEN),
-    UNAUTHORIZED_TO_DELETE_POST("110003", "게시글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
-    ONLY_ADMIN_CAN_CREATE_NOTICE("110004", "공지사항은 관리자만 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
-    ONLY_ADMIN_CAN_UPDATE_NOTICE("110005", "공지사항은 관리자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
-    ONLY_ADMIN_CAN_DELETE_NOTICE("10006", "공지사항은 관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
-    NOT_A_NOTICE("110007", "해당 게시글은 공지사항이 아닙니다.", HttpStatus.BAD_REQUEST),
+    POST_NOT_FOUND("150000", "해당 게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_TO_UPDATE_POST("150001", "게시글은 작성자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_USER_CAN_CREATE_POST("150002", "게시글은 일반 사용자만 작성할 수 있습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED_TO_DELETE_POST("150003", "게시글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_ADMIN_CAN_CREATE_NOTICE("150004", "공지사항은 관리자만 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_ADMIN_CAN_UPDATE_NOTICE("150005", "공지사항은 관리자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_ADMIN_CAN_DELETE_NOTICE("150006", "공지사항은 관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    NOT_A_NOTICE("150007", "해당 게시글은 공지사항이 아닙니다.", HttpStatus.BAD_REQUEST),
 
     /*---------------- 댓글 -------------------------*/
-    COMMENT_NOT_FOUND("120000", "해당 댓글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    UNAUTHORIZED_TO_DELETE_COMMENT("120001", "댓글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
-    UNAUTHORIZED_TO_CREATE_COMMENT("120002", "댓글 작성은 회원만 가능합니다.", HttpStatus.FORBIDDEN),
-    COMMENT_POST_MISMATCH("120003", "해당 댓글은 게시글과 매칭되지 않습니다.", HttpStatus.BAD_REQUEST);
+    COMMENT_NOT_FOUND("160000", "해당 댓글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_TO_DELETE_COMMENT("160001", "댓글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED_TO_CREATE_COMMENT("160002", "댓글 작성은 회원만 가능합니다.", HttpStatus.FORBIDDEN),
+    COMMENT_POST_MISMATCH("160003", "해당 댓글은 게시글과 매칭되지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/newbit/post/service/CommentServiceTest.java
+++ b/src/test/java/com/newbit/post/service/CommentServiceTest.java
@@ -2,6 +2,7 @@ package com.newbit.post.service;
 
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.exception.BusinessException;
+import com.newbit.common.exception.ErrorCode;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.entity.Comment;
@@ -152,8 +153,9 @@ class CommentServiceTest {
 
         assertThatThrownBy(() -> commentService.deleteComment(postId, commentId, user))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("해당 댓글이 존재하지 않습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
     }
+
 
     @Test
     void 댓글_삭제_실패_postId_불일치() {
@@ -180,7 +182,7 @@ class CommentServiceTest {
 
         assertThatThrownBy(() -> commentService.deleteComment(wrongPostId, commentId, user))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("해당 댓글이 존재하지 않습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_POST_MISMATCH);
     }
 
     @Test
@@ -207,7 +209,7 @@ class CommentServiceTest {
 
         assertThatThrownBy(() -> commentService.deleteComment(postId, commentId, user))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("댓글은 작성자만 삭제할 수 있습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_TO_DELETE_COMMENT);
     }
 
 }

--- a/src/test/java/com/newbit/post/service/CommentServiceTest.java
+++ b/src/test/java/com/newbit/post/service/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package com.newbit.post.service;
 
 import com.newbit.auth.model.CustomUser;
+import com.newbit.common.exception.BusinessException;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.entity.Comment;
@@ -150,7 +151,7 @@ class CommentServiceTest {
         when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentService.deleteComment(postId, commentId, user))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("해당 댓글이 존재하지 않습니다.");
     }
 
@@ -178,8 +179,8 @@ class CommentServiceTest {
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
         assertThatThrownBy(() -> commentService.deleteComment(wrongPostId, commentId, user))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 댓글이 존재하지 않거나 게시글과 매칭되지 않습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("해당 댓글이 존재하지 않습니다.");
     }
 
     @Test
@@ -205,7 +206,7 @@ class CommentServiceTest {
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
         assertThatThrownBy(() -> commentService.deleteComment(postId, commentId, user))
-                .isInstanceOf(SecurityException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("댓글은 작성자만 삭제할 수 있습니다.");
     }
 

--- a/src/test/java/com/newbit/post/service/PostServiceNoticeTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceNoticeTest.java
@@ -2,6 +2,7 @@ package com.newbit.post.service;
 
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.exception.BusinessException;
+import com.newbit.common.exception.ErrorCode;
 import com.newbit.post.dto.request.PostCreateRequest;
 import com.newbit.post.dto.request.PostUpdateRequest;
 import com.newbit.post.dto.response.PostResponse;
@@ -82,7 +83,7 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.createNotice(request, normalUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("공지사항은 관리자만 등록할 수 있습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ONLY_ADMIN_CAN_CREATE_NOTICE);
 
         verify(postRepository, never()).save(any(Post.class));
     }
@@ -136,7 +137,7 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.updateNotice(postId, updateRequest, normalUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("공지사항은 관리자만 수정할 수 있습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ONLY_ADMIN_CAN_UPDATE_NOTICE);
 
         verify(postRepository, never()).findById(any());
     }
@@ -169,7 +170,7 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.updateNotice(postId, updateRequest, adminUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("해당 게시글은 공지사항이 아닙니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_A_NOTICE);
     }
 
     @Test
@@ -191,7 +192,7 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.updateNotice(postId, updateRequest, adminUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("해당 게시글이 존재하지 않습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
     }
 
     @Test
@@ -223,10 +224,6 @@ class PostServiceNoticeTest {
     @Test
     void 공지사항_삭제_실패_권한없음() {
         Long postId = 1L;
-        PostUpdateRequest request = PostUpdateRequest.builder()
-                .title("수정 제목")
-                .content("수정 내용")
-                .build();
 
         CustomUser normalUser = CustomUser.builder()
                 .userId(2L)
@@ -237,7 +234,7 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.deleteNotice(postId, normalUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("공지사항은 관리자만 삭제할 수 있습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ONLY_ADMIN_CAN_DELETE_NOTICE);
 
         verify(postRepository, never()).findById(any());
     }
@@ -265,7 +262,7 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.deleteNotice(postId, adminUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("해당 게시글은 공지사항이 아닙니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_A_NOTICE);
     }
 
     @Test
@@ -283,6 +280,6 @@ class PostServiceNoticeTest {
 
         assertThatThrownBy(() -> postService.deleteNotice(postId, adminUser))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("해당 게시글이 존재하지 않습니다.");
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
     }
 }

--- a/src/test/java/com/newbit/post/service/PostServiceTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceTest.java
@@ -1,6 +1,8 @@
 package com.newbit.post.service;
 
 import com.newbit.auth.model.CustomUser;
+import com.newbit.common.exception.BusinessException;
+import com.newbit.common.exception.ErrorCode;
 import com.newbit.post.dto.request.PostUpdateRequest;
 import com.newbit.post.dto.request.PostCreateRequest;
 import com.newbit.post.dto.response.PostResponse;
@@ -16,8 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,8 +96,8 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> postService.updatePost(postId, updateRequest, user))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 게시글이 존재하지 않습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.POST_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -125,8 +125,8 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
         assertThatThrownBy(() -> postService.updatePost(postId, updateRequest, user))
-                .isInstanceOf(SecurityException.class)
-                .hasMessage("게시글은 작성자만 수정할 수 있습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.UNAUTHORIZED_TO_UPDATE_POST.getMessage());
     }
 
     @Test
@@ -172,8 +172,8 @@ class PostServiceTest {
 
         // when & then
         assertThatThrownBy(() -> postService.createPost(adminRequest, adminUser))
-                .isInstanceOf(SecurityException.class)
-                .hasMessage("게시글은 일반 사용자만 작성할 수 있습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ONLY_USER_CAN_CREATE_POST.getMessage());
 
         verify(postRepository, never()).save(any(Post.class));
     }
@@ -216,8 +216,8 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> postService.deletePost(postId, user))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 게시글이 존재하지 않습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.POST_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -240,8 +240,8 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
         assertThatThrownBy(() -> postService.deletePost(postId, user))
-                .isInstanceOf(SecurityException.class)
-                .hasMessage("게시글은 작성자만 삭제할 수 있습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.UNAUTHORIZED_TO_DELETE_POST.getMessage());
     }
 
 


### PR DESCRIPTION
### 🛰️ Issue
close #291 	

### 🪐 작업 내용
ErrorCode enum 수정(게시글 및 댓글 관련 에러 코드 추가 및 정리)
PostService, CommentService 비즈니스 로직 예외 처리 리팩토링
CommentServiceTest, PostServiceTest, PostServiceNoticeTest 단위 테스트 리팩토링

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] Swagger API 테스트
- [x] 단위 테스트
