### PR TITLE
Nbt 81 be 관리자 칼럼 등록 요청 승인 거절 기능 구현

### DIFF
--- a/src/main/java/com/newbit/column/controller/AdminColumnController.java
+++ b/src/main/java/com/newbit/column/controller/AdminColumnController.java
@@ -1,0 +1,40 @@
+package com.newbit.column.controller;
+
+import com.newbit.auth.model.CustomUser;
+import com.newbit.column.dto.request.ApproveColumnRequestDto;
+import com.newbit.column.dto.request.RejectColumnRequestDto;
+import com.newbit.column.dto.response.AdminColumnResponseDto;
+import com.newbit.column.service.AdminColumnService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/columns")
+public class AdminColumnController {
+
+    private final AdminColumnService adminColumnService;
+
+    @PostMapping("/requests/approve/create")
+    @Operation(summary = "칼럼 등록 요청 승인", description = "CREATE 타입의 칼럼 등록 요청을 승인합니다.")
+    public AdminColumnResponseDto approveCreateColumn(
+            @RequestBody ApproveColumnRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+            ) {
+        return adminColumnService.approveCreateColumnRequest(dto, customUser.getUserId());
+    }
+
+    @PostMapping("/requests/reject/create")
+    @Operation(summary = "칼럼 등록 요청 거절", description = "CREATE 타입의 칼럼 등록 요청을 거절하고, 거절 사유를 기록합니다.")
+    public AdminColumnResponseDto rejectCreateColumn(
+            @RequestBody RejectColumnRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        return adminColumnService.rejectCreateColumnRequest(dto, customUser.getUserId());
+    }
+}

--- a/src/main/java/com/newbit/column/domain/Column.java
+++ b/src/main/java/com/newbit/column/domain/Column.java
@@ -67,6 +67,10 @@ public class Column {
         this.deletedAt = LocalDateTime.now();
     }
 
+    public void approve() {
+        this.isPublic = true;
+    }
+
     public void updateSeries(Series series) {
         this.series = series;
     }

--- a/src/main/java/com/newbit/column/domain/ColumnRequest.java
+++ b/src/main/java/com/newbit/column/domain/ColumnRequest.java
@@ -50,6 +50,19 @@ public class ColumnRequest {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    public void approve(Long adminUserId) {
+        this.isApproved = true;
+        this.adminUserId = adminUserId;
+        this.getColumn().approve();
+    }
+
+    public void reject(String reason, Long adminUserId) {
+        this.isApproved = false;
+        this.rejectedReason = reason;
+        this.adminUserId = adminUserId;
+    }
+
+
     /* 현재 사용하지 않음. 추후 테스트/기타 로직에 활용 가능 */
 //    public static ColumnRequest createdColumnRequest(CreateColumnRequestDto dto, Column column) {
 //        return ColumnRequest.builder()

--- a/src/main/java/com/newbit/column/dto/request/ApproveColumnRequestDto.java
+++ b/src/main/java/com/newbit/column/dto/request/ApproveColumnRequestDto.java
@@ -1,0 +1,11 @@
+package com.newbit.column.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ApproveColumnRequestDto {
+
+    @Schema(description = "승인할 칼럼 요청 ID", example = "1")
+    private Long columnRequestId;
+}

--- a/src/main/java/com/newbit/column/dto/request/RejectColumnRequestDto.java
+++ b/src/main/java/com/newbit/column/dto/request/RejectColumnRequestDto.java
@@ -1,0 +1,14 @@
+package com.newbit.column.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class RejectColumnRequestDto {
+
+    @Schema(description = "거절할 칼럼 요청 ID", example = "1")
+    private Long columnRequestId;
+
+    @Schema(description = "거절 사유", example = "내용이 부적절합니다.")
+    private String reason;
+}

--- a/src/main/java/com/newbit/column/dto/response/AdminColumnResponseDto.java
+++ b/src/main/java/com/newbit/column/dto/response/AdminColumnResponseDto.java
@@ -1,0 +1,24 @@
+package com.newbit.column.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "관리자 칼럼 요청 응답")
+public class AdminColumnResponseDto {
+
+    @Schema(description = "칼럼 요청 ID", example = "1")
+    Long requestId;
+
+    @Schema(description = "요청 유형", example = "CREATE")
+    String requestType;
+
+    @Schema(description = "요청 승인 여부", example = "true")
+    Boolean isApproved;
+
+    @Schema(description = "칼럼 ID", example = "10")
+    Long columnId;
+
+}

--- a/src/main/java/com/newbit/column/mapper/AdminColumnMapper.java
+++ b/src/main/java/com/newbit/column/mapper/AdminColumnMapper.java
@@ -1,0 +1,18 @@
+package com.newbit.column.mapper;
+
+import com.newbit.column.domain.ColumnRequest;
+import com.newbit.column.dto.response.AdminColumnResponseDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminColumnMapper {
+
+    public AdminColumnResponseDto toDto(ColumnRequest request) {
+        return AdminColumnResponseDto.builder()
+                .requestId(request.getColumnRequestId())
+                .requestType(request.getRequestType().name())
+                .isApproved(request.getIsApproved())
+                .columnId(request.getColumn().getColumnId())
+                .build();
+    }
+}

--- a/src/main/java/com/newbit/column/service/AdminColumnService.java
+++ b/src/main/java/com/newbit/column/service/AdminColumnService.java
@@ -1,0 +1,53 @@
+package com.newbit.column.service;
+
+import com.newbit.column.domain.ColumnRequest;
+import com.newbit.column.dto.request.ApproveColumnRequestDto;
+import com.newbit.column.dto.request.RejectColumnRequestDto;
+import com.newbit.column.dto.response.AdminColumnResponseDto;
+import com.newbit.column.enums.RequestType;
+import com.newbit.column.mapper.AdminColumnMapper;
+import com.newbit.column.repository.ColumnRequestRepository;
+import com.newbit.common.exception.BusinessException;
+import com.newbit.common.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminColumnService {
+
+    private final ColumnRequestRepository columnRequestRepository;
+    private final AdminColumnMapper adminColumnMapper;
+
+    @Transactional
+    @Operation(summary = "칼럼 등록 요청 승인", description = "CREATE 타입의 칼럼 요청을 승인하고, 해당 칼럼을 공개 상태로 변경합니다.")
+    public AdminColumnResponseDto approveCreateColumnRequest(ApproveColumnRequestDto dto, Long adminUserId) {
+        ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
+
+        if (request.getRequestType() != RequestType.CREATE) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_TYPE);
+        }
+
+        request.approve(adminUserId);
+        return adminColumnMapper.toDto(request);
+    }
+
+    @Transactional
+    @Operation(summary = "칼럼 등록 요청 거절", description = "CREATE 타입의 칼럼 요청을 거절하고, 거절 사유를 기록합니다.")
+    public AdminColumnResponseDto rejectCreateColumnRequest(RejectColumnRequestDto dto, Long adminUserId) {
+        ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
+
+        if (request.getRequestType() != RequestType.CREATE) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_TYPE);
+        }
+
+        request.reject(dto.getReason(), adminUserId);
+        return adminColumnMapper.toDto(request);
+    }
+
+
+}

--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -60,7 +60,8 @@ public enum ErrorCode {
     COLUMN_NOT_FOUND("60003", "해당 칼럼을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     COLUMN_NOT_OWNED("60011", "해당 칼럼에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
     COLUMN_ALREADY_IN_SERIES("60012", "해당 칼럼은 이미 다른 시리즈에 속해있습니다.", HttpStatus.BAD_REQUEST),
-
+    COLUMN_REQUEST_NOT_FOUND("60013", "해당 칼럼 요청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_REQUEST_TYPE("60014", "잘못된 요청 타입 입니다.", HttpStatus.BAD_REQUEST),
     // 시리즈 오류
     SERIES_CREATION_REQUIRES_COLUMNS("300000", "시리즈는 최소 1개 이상의 칼럼으로 생성되어야 합니다.", HttpStatus.BAD_REQUEST),
     SERIES_NOT_FOUND("300001", "해당 시리즈를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/test/java/com/newbit/column/service/AdminColumnServiceTest.java
+++ b/src/test/java/com/newbit/column/service/AdminColumnServiceTest.java
@@ -1,0 +1,154 @@
+package com.newbit.column.service;
+
+import com.newbit.column.domain.Column;
+import com.newbit.column.domain.ColumnRequest;
+import com.newbit.column.dto.request.ApproveColumnRequestDto;
+import com.newbit.column.dto.request.RejectColumnRequestDto;
+import com.newbit.column.dto.response.AdminColumnResponseDto;
+import com.newbit.column.enums.RequestType;
+import com.newbit.column.mapper.AdminColumnMapper;
+import com.newbit.column.repository.ColumnRequestRepository;
+import com.newbit.common.exception.BusinessException;
+import com.newbit.common.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminColumnServiceTest {
+
+    @InjectMocks
+    private AdminColumnService adminColumnService;
+
+    @Mock
+    private ColumnRequestRepository columnRequestRepository;
+
+    @Mock
+    private AdminColumnMapper adminColumnMapper;
+
+    @BeforeEach
+    void setUp() {
+        // MockitoAnnotations.openMocks(this); // MockitoExtension으로 대체
+    }
+
+    @Test
+    @DisplayName("칼럼 등록 요청 승인 - 성공")
+    void approveCreateColumnRequest_success() {
+        // given
+        Long requestId = 1L;
+        Long adminUserId = 100L;
+        ApproveColumnRequestDto dto = new ApproveColumnRequestDto();
+        ReflectionTestUtils.setField(dto, "columnRequestId", requestId);
+
+        Column column = Column.builder().columnId(10L).build();
+        ColumnRequest request = ColumnRequest.builder()
+                .columnRequestId(requestId)
+                .requestType(RequestType.CREATE)
+                .isApproved(null)
+                .column(column)
+                .build();
+
+        AdminColumnResponseDto responseDto = AdminColumnResponseDto.builder()
+                .requestId(requestId)
+                .requestType("CREATE")
+                .isApproved(true)
+                .columnId(column.getColumnId())
+                .build();
+
+        when(columnRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+        when(adminColumnMapper.toDto(any())).thenReturn(responseDto);
+
+        // when
+        AdminColumnResponseDto result = adminColumnService.approveCreateColumnRequest(dto, adminUserId);
+
+        // then
+        assertThat(result.getRequestId()).isEqualTo(requestId);
+        assertThat(result.getIsApproved()).isTrue();
+        verify(columnRequestRepository).findById(requestId);
+    }
+
+    @Test
+    @DisplayName("칼럼 등록 요청 승인 - 잘못된 요청 타입 예외")
+    void approveCreateColumnRequest_invalidRequestType_throwsException() {
+        // given
+        Long requestId = 2L;
+        ApproveColumnRequestDto dto = new ApproveColumnRequestDto();
+        ReflectionTestUtils.setField(dto, "columnRequestId", requestId);
+
+        ColumnRequest request = ColumnRequest.builder()
+                .columnRequestId(requestId)
+                .requestType(RequestType.UPDATE) // 잘못된 타입
+                .build();
+
+        when(columnRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+        // when & then
+        assertThatThrownBy(() -> adminColumnService.approveCreateColumnRequest(dto, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_REQUEST_TYPE.getMessage());
+    }
+
+    @Test
+    @DisplayName("칼럼 등록 요청 거절 - 성공")
+    void rejectCreateColumnRequest_success() {
+        // given
+        Long requestId = 3L;
+        Long adminUserId = 101L;
+        RejectColumnRequestDto dto = new RejectColumnRequestDto();
+        ReflectionTestUtils.setField(dto, "columnRequestId", requestId);
+        ReflectionTestUtils.setField(dto, "reason", "부적절한 내용");
+
+        Column column = Column.builder().columnId(20L).build();
+        ColumnRequest request = ColumnRequest.builder()
+                .columnRequestId(requestId)
+                .requestType(RequestType.CREATE)
+                .isApproved(null)
+                .column(column)
+                .build();
+
+        AdminColumnResponseDto responseDto = AdminColumnResponseDto.builder()
+                .requestId(requestId)
+                .requestType("CREATE")
+                .isApproved(false)
+                .columnId(column.getColumnId())
+                .build();
+
+        when(columnRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+        when(adminColumnMapper.toDto(any())).thenReturn(responseDto);
+
+        // when
+        AdminColumnResponseDto result = adminColumnService.rejectCreateColumnRequest(dto, adminUserId);
+
+        // then
+        assertThat(result.getIsApproved()).isFalse();
+        assertThat(result.getColumnId()).isEqualTo(column.getColumnId());
+    }
+
+    @Test
+    @DisplayName("칼럼 등록 요청 거절 - 요청 없음 예외")
+    void rejectCreateColumnRequest_requestNotFound_throwsException() {
+        // given
+        Long requestId = 99L;
+        RejectColumnRequestDto dto = new RejectColumnRequestDto();
+        ReflectionTestUtils.setField(dto, "columnRequestId", requestId);
+
+        when(columnRequestRepository.findById(requestId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminColumnService.rejectCreateColumnRequest(dto, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.COLUMN_REQUEST_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
Nbt 81 be 관리자 칼럼 등록 요청 승인 거절 기능 구현
### 🪐 작업 내용
- /requests/approve/create, /requests/reject/create POST 엔드포인트 추가
- Swagger 설명 어노테이션 적용
- AdminColumnService 로직 구현
  - approveCreateColumnRequest(): 승인 처리 및 칼럼 공개 처리
  - rejectCreateColumnRequest(): 거절 처리 및 사유 저장
- ColumnRequest → AdminColumnResponseDto 매핑 메서드 추가

- ErrorCode에 INVALID_REQUEST_TYPE 항목 HttpStatus 누락 부분 보완
- 테스트 코드 (AdminColumnServiceTest) 작성
  - 승인 성공, 승인 실패(잘못된 타입)