### PR TITLE
Nbt 82 be 관리자 칼럼 수정 요청 승인 거절 기능 구현

### DIFF
--- a/src/main/java/com/newbit/column/controller/AdminColumnController.java
+++ b/src/main/java/com/newbit/column/controller/AdminColumnController.java
@@ -37,4 +37,22 @@ public class AdminColumnController {
     ) {
         return adminColumnService.rejectCreateColumnRequest(dto, customUser.getUserId());
     }
+
+    @PostMapping("/requests/approve/update")
+    @Operation(summary = "칼럼 수정 요청 승인", description = "UPDATE 타입의 칼럼 수정 요청을 승인합니다.")
+    public AdminColumnResponseDto approveUpdateColumn(
+            @RequestBody ApproveColumnRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        return adminColumnService.approveUpdateColumnRequest(dto, customUser.getUserId());
+    }
+
+    @PostMapping("/requests/reject/update")
+    @Operation(summary = "칼럼 수정 요청 거절", description = "UPDATE 타입의 칼럼 수정 요청을 거절합니다.")
+    public AdminColumnResponseDto rejectUpdateColumn(
+            @RequestBody RejectColumnRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        return adminColumnService.rejectUpdateColumnRequest(dto, customUser.getUserId());
+    }
 }

--- a/src/main/java/com/newbit/column/domain/Column.java
+++ b/src/main/java/com/newbit/column/domain/Column.java
@@ -74,7 +74,14 @@ public class Column {
     public void updateSeries(Series series) {
         this.series = series;
     }
-    
+
+    public void updateContent(String title, String content, Integer price, String thumbnailUrl) {
+        if (title != null) this.title = title;
+        if (content != null) this.content = content;
+        if (price != null) this.price = price;
+        if (thumbnailUrl != null) this.thumbnailUrl = thumbnailUrl;
+    }
+
     // 좋아요 카운트 증가
     public void increaseLikeCount() {
         this.likeCount += 1;

--- a/src/main/java/com/newbit/column/service/AdminColumnService.java
+++ b/src/main/java/com/newbit/column/service/AdminColumnService.java
@@ -1,5 +1,6 @@
 package com.newbit.column.service;
 
+import com.newbit.column.domain.Column;
 import com.newbit.column.domain.ColumnRequest;
 import com.newbit.column.dto.request.ApproveColumnRequestDto;
 import com.newbit.column.dto.request.RejectColumnRequestDto;
@@ -22,7 +23,6 @@ public class AdminColumnService {
     private final AdminColumnMapper adminColumnMapper;
 
     @Transactional
-    @Operation(summary = "칼럼 등록 요청 승인", description = "CREATE 타입의 칼럼 요청을 승인하고, 해당 칼럼을 공개 상태로 변경합니다.")
     public AdminColumnResponseDto approveCreateColumnRequest(ApproveColumnRequestDto dto, Long adminUserId) {
         ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
@@ -36,7 +36,6 @@ public class AdminColumnService {
     }
 
     @Transactional
-    @Operation(summary = "칼럼 등록 요청 거절", description = "CREATE 타입의 칼럼 요청을 거절하고, 거절 사유를 기록합니다.")
     public AdminColumnResponseDto rejectCreateColumnRequest(RejectColumnRequestDto dto, Long adminUserId) {
         ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
@@ -49,5 +48,34 @@ public class AdminColumnService {
         return adminColumnMapper.toDto(request);
     }
 
+    @Transactional
+    public AdminColumnResponseDto approveUpdateColumnRequest(ApproveColumnRequestDto dto, Long adminUserId) {
+        ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
 
+        if (request.getRequestType() != RequestType.UPDATE) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_TYPE);
+        }
+
+        // 칼럼 정보 업데이트
+        Column column = request.getColumn();
+        column.updateContent(request.getUpdatedTitle(), request.getUpdatedContent(), request.getUpdatedPrice(), request.getUpdatedThumbnailUrl());
+
+        // 승인 처리
+        request.approve(adminUserId);
+        return adminColumnMapper.toDto(request);
+    }
+
+    @Transactional
+    public AdminColumnResponseDto rejectUpdateColumnRequest(RejectColumnRequestDto dto, Long adminUserId) {
+        ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
+
+        if (request.getRequestType() != RequestType.UPDATE) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_TYPE);
+        }
+
+        request.reject(dto.getReason(), adminUserId);
+        return adminColumnMapper.toDto(request);
+    }
 }


### PR DESCRIPTION
### 🛰️ Issue
Nbt 82 be 관리자 칼럼 수정 요청 승인 거절 기능 구현	

### 🪐 작업 내용
- 관리자용 칼럼 수정 요청 승인/거절 기능 구현
  - 승인 시: 요청된 내용으로 실제 칼럼 정보 수정
  - 거절 시: 거절 사유 및 관리자 ID 저장
