### PR TITLE
Nbt 83 be 관리자 칼럼 삭제 요청 승인 거절 기능 구현

### DIFF
--- a/src/main/java/com/newbit/column/controller/AdminColumnController.java
+++ b/src/main/java/com/newbit/column/controller/AdminColumnController.java
@@ -55,4 +55,23 @@ public class AdminColumnController {
     ) {
         return adminColumnService.rejectUpdateColumnRequest(dto, customUser.getUserId());
     }
+
+    @PostMapping("/requests/approve/delete")
+    @Operation(summary = "칼럼 삭제 요청 승인", description = "DELETE 타입의 칼럼 삭제 요청을 승인하고, 칼럼을 삭제 처리합니다.")
+    public AdminColumnResponseDto approveDeleteColumn(
+            @RequestBody ApproveColumnRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        return adminColumnService.approveDeleteColumnRequest(dto, customUser.getUserId());
+    }
+
+    @PostMapping("/requests/reject/delete")
+    @Operation(summary = "칼럼 삭제 요청 거절", description = "DELETE 타입의 칼럼 삭제 요청을 거절하고, 거절 사유를 기록합니다.")
+    public AdminColumnResponseDto rejectDeleteColumn(
+            @RequestBody RejectColumnRequestDto dto,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
+        return adminColumnService.rejectDeleteColumnRequest(dto, customUser.getUserId());
+    }
+
 }

--- a/src/main/java/com/newbit/column/service/AdminColumnService.java
+++ b/src/main/java/com/newbit/column/service/AdminColumnService.java
@@ -78,4 +78,36 @@ public class AdminColumnService {
         request.reject(dto.getReason(), adminUserId);
         return adminColumnMapper.toDto(request);
     }
+
+    @Transactional
+    public AdminColumnResponseDto approveDeleteColumnRequest(ApproveColumnRequestDto dto, Long adminUserId) {
+        ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
+
+        if (request.getRequestType() != RequestType.DELETE) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_TYPE);
+        }
+
+        // 삭제 처리
+        Column column = request.getColumn();
+        column.markAsDeleted();
+
+        // 승인 처리
+        request.approve(adminUserId);
+        return adminColumnMapper.toDto(request);
+    }
+
+    @Transactional
+    public AdminColumnResponseDto rejectDeleteColumnRequest(RejectColumnRequestDto dto, Long adminUserId) {
+        ColumnRequest request = columnRequestRepository.findById(dto.getColumnRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.COLUMN_REQUEST_NOT_FOUND));
+
+        if (request.getRequestType() != RequestType.DELETE) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_TYPE);
+        }
+
+        request.reject(dto.getReason(), adminUserId);
+        return adminColumnMapper.toDto(request);
+    }
+
 }


### PR DESCRIPTION
### 🛰️ Issue
Nbt 83 be 관리자 칼럼 삭제 요청 승인 거절 기능 구현	

### 🪐 작업 내용
- 관리자용 칼럼 삭제 요청 승인/거절 기능 구현
  - 승인 시: Column.markAsDeleted() 호출하여 deletedAt 필드에 삭제 시간 설정
  - 거절 시: 거절 사유(rejectedReason) 및 관리자 ID 저장

- AdminColumnService에 승인/거절 메서드 추가
  - approveDeleteColumnRequest()
  - rejectDeleteColumnRequest()