### PR TITLE
[BE] NBT-196 칼럼, 게시글 관련 알림 발송 처리

### DIFF
--- a/src/main/java/com/newbit/column/service/AdminColumnService.java
+++ b/src/main/java/com/newbit/column/service/AdminColumnService.java
@@ -10,6 +10,8 @@ import com.newbit.column.mapper.AdminColumnMapper;
 import com.newbit.column.repository.ColumnRequestRepository;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,7 @@ public class AdminColumnService {
 
     private final ColumnRequestRepository columnRequestRepository;
     private final AdminColumnMapper adminColumnMapper;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public AdminColumnResponseDto approveCreateColumnRequest(ApproveColumnRequestDto dto, Long adminUserId) {
@@ -32,6 +35,19 @@ public class AdminColumnService {
         }
 
         request.approve(adminUserId);
+
+        String notificationContent = String.format("'%s' 칼럼 등록이 승인되었습니다.",
+                request.getColumn().getTitle());
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        request.getColumn().getMentor().getUser().getUserId()
+                        , 11L
+                        , request.getColumnRequestId(),
+                        notificationContent
+                )
+        );
+
         return adminColumnMapper.toDto(request);
     }
 
@@ -45,6 +61,19 @@ public class AdminColumnService {
         }
 
         request.reject(dto.getReason(), adminUserId);
+
+        String notificationContent = String.format("'%s' 칼럼 등록이 거절되었습니다.",
+                request.getColumn().getTitle());
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        request.getColumn().getMentor().getUser().getUserId()
+                        , 12L
+                        , request.getColumnRequestId(),
+                        notificationContent
+                )
+        );
+
         return adminColumnMapper.toDto(request);
     }
 
@@ -63,6 +92,21 @@ public class AdminColumnService {
 
         // 승인 처리
         request.approve(adminUserId);
+
+
+        String notificationContent = String.format("'%s' 칼럼이 수정 승인되었습니다.",
+                request.getUpdatedTitle());
+
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        request.getColumn().getMentor().getUser().getUserId()
+                        , 11L
+                        , request.getColumnRequestId(),
+                        notificationContent
+                )
+        );
+
         return adminColumnMapper.toDto(request);
     }
 
@@ -76,6 +120,21 @@ public class AdminColumnService {
         }
 
         request.reject(dto.getReason(), adminUserId);
+
+
+        String notificationContent = String.format("'%s' 칼럼이 수정이 거절되었습니다.",
+                request.getColumn().getTitle());
+
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        request.getColumn().getMentor().getUser().getUserId()
+                        , 12L
+                        , request.getColumnRequestId(),
+                        notificationContent
+                )
+        );
+
         return adminColumnMapper.toDto(request);
     }
 }

--- a/src/main/java/com/newbit/column/service/AdminColumnService.java
+++ b/src/main/java/com/newbit/column/service/AdminColumnService.java
@@ -94,7 +94,7 @@ public class AdminColumnService {
         request.approve(adminUserId);
 
 
-        String notificationContent = String.format("'%s' 칼럼이 수정 승인되었습니다.",
+        String notificationContent = String.format("'%s' 칼럼 수정이 승인되었습니다.",
                 request.getUpdatedTitle());
 
 
@@ -122,7 +122,7 @@ public class AdminColumnService {
         request.reject(dto.getReason(), adminUserId);
 
 
-        String notificationContent = String.format("'%s' 칼럼이 수정이 거절되었습니다.",
+        String notificationContent = String.format("'%s' 칼럼 수정이 거절되었습니다.",
                 request.getColumn().getTitle());
 
 
@@ -153,6 +153,20 @@ public class AdminColumnService {
 
         // 승인 처리
         request.approve(adminUserId);
+
+        String notificationContent = String.format("'%s' 칼럼 삭제가 승인되었습니다.",
+                request.getColumn().getTitle());
+
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        request.getColumn().getMentor().getUser().getUserId()
+                        , 11L
+                        , request.getColumnRequestId(),
+                        notificationContent
+                )
+        );
+
         return adminColumnMapper.toDto(request);
     }
 
@@ -166,6 +180,20 @@ public class AdminColumnService {
         }
 
         request.reject(dto.getReason(), adminUserId);
+
+        String notificationContent = String.format("'%s' 칼럼 삭제가 거절되었습니다.",
+                request.getColumn().getTitle());
+
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        request.getColumn().getMentor().getUser().getUserId()
+                        , 12L
+                        , request.getColumnRequestId(),
+                        notificationContent
+                )
+        );
+
         return adminColumnMapper.toDto(request);
     }
 

--- a/src/main/java/com/newbit/like/service/LikeCommandService.java
+++ b/src/main/java/com/newbit/like/service/LikeCommandService.java
@@ -111,6 +111,21 @@ public class LikeCommandService {
             increaseLikeCount(post);
             
             pointRewardService.givePointIfFirstLike(postId, userId, post.getUserId());
+
+            if(isFibonacci(post.getLikeCount())){
+                String notificationContent = String.format("'%s' 게시글이 좋아요를 받았습니다. (총 %d개)",
+                        post.getTitle(), post.getLikeCount());
+
+                notificationCommandService.sendNotification(
+                        new NotificationSendRequest(
+                                post.getUserId()
+                                , 2L // 예: 좋아요 알림 유형 ID
+                                , postId,
+                                notificationContent
+                        )
+                );
+            }
+
             
             return PostLikeResponse.of(like, post.getLikeCount());
         } catch (Exception e) {

--- a/src/main/java/com/newbit/like/service/LikeCommandService.java
+++ b/src/main/java/com/newbit/like/service/LikeCommandService.java
@@ -2,6 +2,8 @@ package com.newbit.like.service;
 
 import java.util.Optional;
 
+import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ public class LikeCommandService {
     private final PostRepository postRepository;
     private final ColumnRepository columnRepository;
     private final PointRewardService pointRewardService;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public PostLikeResponse togglePostLike(Long postId, Long userId) {
@@ -170,7 +173,22 @@ public class LikeCommandService {
             
             column.increaseLikeCount();
             columnRepository.save(column);
-            
+
+            if(isFibonacci(column.getLikeCount())){
+                String notificationContent = String.format("'%s' 칼럼이 좋아요를 받았습니다. (총 %d개)",
+                        column.getTitle(), column.getLikeCount());
+
+                notificationCommandService.sendNotification(
+                        new NotificationSendRequest(
+                                column.getMentor().getUser().getUserId()
+                                , 2L // 예: 좋아요 알림 유형 ID
+                                , columnId,
+                                notificationContent
+                        )
+                );
+            }
+
+
             return ColumnLikeResponse.of(like, column.getLikeCount());
         } catch (Exception e) {
             log.error("칼럼 좋아요 추가 처리 중 오류 발생: columnId={}, userId={}, error={}", 
@@ -178,7 +196,18 @@ public class LikeCommandService {
             throw new BusinessException(ErrorCode.LIKE_PROCESSING_ERROR);
         }
     }
-    
+
+    private boolean isFibonacci(int n) {
+        int a = 0, b = 1;
+        while (b < n) {
+            int temp = b;
+            b = a + b;
+            a = temp;
+        }
+        return b == n;
+    }
+
+
     private Like createColumnLike(Long columnId, Long userId) {
         return Like.builder()
                 .columnId(columnId)

--- a/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
+++ b/src/main/java/com/newbit/notification/command/application/controller/NotificationCommandController.java
@@ -35,7 +35,7 @@ public class NotificationCommandController {
         Long userId = customUser.getUserId();
 
         String emitterId = userId + "_" + UUID.randomUUID();
-        SseEmitter emitter = new SseEmitter(60 * 1000L); // 60초 타임아웃
+        SseEmitter emitter = new SseEmitter(60 * 60 * 1000L); // 60초 타임아웃
 
         sseEmitterRepository.save(emitterId, userId, emitter);
 

--- a/src/main/java/com/newbit/notification/command/application/dto/request/NotificationSendRequest.java
+++ b/src/main/java/com/newbit/notification/command/application/dto/request/NotificationSendRequest.java
@@ -20,7 +20,7 @@ public class NotificationSendRequest {
     @Schema(description = "알림 유형 ID", example = "2")
     private Long notificationTypeId;
 
-    @Schema(description = "서비스 유형", example = "3")
+    @Schema(description = "서비스 ID", example = "3")
     private Long serviceId;
 
     @NotBlank

--- a/src/main/java/com/newbit/post/service/CommentService.java
+++ b/src/main/java/com/newbit/post/service/CommentService.java
@@ -3,6 +3,9 @@ package com.newbit.post.service;
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.notification.command.application.service.NotificationCommandService;
+import com.newbit.notification.command.domain.repository.NotificationRepository;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.entity.Comment;
@@ -24,6 +27,8 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final PointTransactionCommandService pointTransactionCommandService;
+    private final NotificationRepository notificationRepository;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public CommentResponse createComment(Long postId, CommentCreateRequest request, CustomUser user) {
@@ -39,6 +44,19 @@ public class CommentService {
 
         commentRepository.save(comment);
         pointTransactionCommandService.givePointByType(user.getUserId(), "댓글 적립", comment.getId());
+
+        String notificationContent = String.format("'%s' 게시글에 댓글이 달렸습니다. ('%s')",
+                post.getTitle(), comment.getContent());
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        post.getUserId()
+                        , 1L
+                        , postId
+                        , notificationContent
+                )
+        );
+
         return new CommentResponse(comment);
     }
 

--- a/src/main/java/com/newbit/post/service/CommentService.java
+++ b/src/main/java/com/newbit/post/service/CommentService.java
@@ -27,7 +27,6 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final PointTransactionCommandService pointTransactionCommandService;
-    private final NotificationRepository notificationRepository;
     private final NotificationCommandService notificationCommandService;
 
     @Transactional

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -183,4 +183,5 @@ public class PostService {
 
         post.softDelete();
     }
+
 }

--- a/src/test/java/com/newbit/post/service/CommentServiceTest.java
+++ b/src/test/java/com/newbit/post/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.newbit.post.service;
 import com.newbit.auth.model.CustomUser;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.post.dto.request.CommentCreateRequest;
 import com.newbit.post.dto.response.CommentResponse;
 import com.newbit.post.entity.Comment;
@@ -26,16 +27,16 @@ class CommentServiceTest {
 
     private CommentRepository commentRepository;
     private PostRepository postRepository;
-    private PointTransactionCommandService pointTransactionCommandService;
     private CommentService commentService;
 
     @BeforeEach
     void setUp() {
         commentRepository = mock(CommentRepository.class);
         postRepository = mock(PostRepository.class);
-        pointTransactionCommandService = mock(PointTransactionCommandService.class);
+        PointTransactionCommandService pointTransactionCommandService = mock(PointTransactionCommandService.class);
+        NotificationCommandService notificationCommandService = mock(NotificationCommandService.class);
 
-        commentService = new CommentService(commentRepository, postRepository, pointTransactionCommandService);
+        commentService = new CommentService(commentRepository, postRepository, pointTransactionCommandService, notificationCommandService);
     }
 
     @Test


### PR DESCRIPTION
### 🛰️ Issue
NBT-196 칼럼, 게시글 관련 알림 발송 처리(#286)

### 🪐 작업 내용
- 게시글에 댓글이 생성될 때 게시글의 작성자에게 알림이 발송되도록 한다.
- 사용자가 작성한 게시글, 칼럼에 좋아요가 피보나치 수가 될 때마다 작성자에게 실시간으로 알림이 발송되도록 한다.
- 칼럼에 대한 요청(등록, 수정, 삭제) 결과에 대한 알림 발송 처리
- 코드 수정에 따른 테스트 코드 수정
<img width="1151" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/6b835ce7-a4cd-4463-83d3-ef1862bfc6c6" />


### ✅ Check List (선택)
- [x] Postman으로 알림 발송 확인
- [x] 테스트 코드 성공
