### PR TITLE
Nbt 185 정산 내역 계산 및 생성 기능 구현

### DIFF
--- a/src/main/java/com/newbit/purchase/command/domain/aggregate/SaleHistory.java
+++ b/src/main/java/com/newbit/purchase/command/domain/aggregate/SaleHistory.java
@@ -79,4 +79,8 @@ public class SaleHistory {
                 .build();
     }
 
+    public void markAsSettled() {
+        this.settledAt = LocalDateTime.now();
+        this.isSettled = true;
+    }
 }

--- a/src/main/java/com/newbit/purchase/command/domain/repository/SaleHistoryRepository.java
+++ b/src/main/java/com/newbit/purchase/command/domain/repository/SaleHistoryRepository.java
@@ -2,6 +2,11 @@ package com.newbit.purchase.command.domain.repository;
 
 import com.newbit.purchase.command.domain.aggregate.SaleHistory;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface SaleHistoryRepository{
     SaleHistory save(SaleHistory saleHistory);
+
+    List<SaleHistory> findAllByIsSettledFalseAndCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/newbit/settlement/controller/MentorSettlementController.java
+++ b/src/main/java/com/newbit/settlement/controller/MentorSettlementController.java
@@ -1,0 +1,34 @@
+package com.newbit.settlement.controller;
+
+import com.newbit.settlement.service.MentorSettlementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/settlements")
+@Tag(name = "멘토 정산", description = "멘토 월별 정산 관련 API")
+public class MentorSettlementController {
+
+    private final MentorSettlementService settlementService;
+
+    @PostMapping("/generate")
+    @Operation(
+            summary = "멘토 월별 정산 생성",
+            description = "특정 연도와 월을 기준으로 멘토 정산 내역을 생성하고, 관련된 판매내역을 정산 완료 상태로 변경합니다."
+    )
+    public ResponseEntity<Void> generateMonthlySettlement(
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        settlementService.generateMonthlySettlements(year, month);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/com/newbit/settlement/entity/MonthlySettlementHistory.java
+++ b/src/main/java/com/newbit/settlement/entity/MonthlySettlementHistory.java
@@ -1,0 +1,53 @@
+package com.newbit.settlement.entity;
+
+import com.newbit.user.entity.Mentor;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "monthly_settlement_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class MonthlySettlementHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long monthlySettlementHistoryId;
+
+    private int settlementYear;
+    private int settlementMonth;
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal settlementAmount;
+
+    private LocalDateTime settledAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id", nullable = false)
+    private Mentor mentor;
+
+    public static MonthlySettlementHistory of(Mentor mentor, int year, int month, BigDecimal amount) {
+        return MonthlySettlementHistory.builder()
+                .mentor(mentor)
+                .settlementYear(year)
+                .settlementMonth(month)
+                .settlementAmount(amount)
+                .settledAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/newbit/settlement/repository/MonthlySettlementHistoryRepository.java
+++ b/src/main/java/com/newbit/settlement/repository/MonthlySettlementHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.newbit.settlement.repository;
+
+import com.newbit.settlement.entity.MonthlySettlementHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlySettlementHistoryRepository extends JpaRepository<MonthlySettlementHistory, Long> {
+}

--- a/src/main/java/com/newbit/settlement/service/MentorSettlementService.java
+++ b/src/main/java/com/newbit/settlement/service/MentorSettlementService.java
@@ -1,0 +1,62 @@
+package com.newbit.settlement.service;
+
+import com.newbit.purchase.command.domain.aggregate.SaleHistory;
+import com.newbit.purchase.command.domain.repository.SaleHistoryRepository;
+import com.newbit.settlement.entity.MonthlySettlementHistory;
+import com.newbit.settlement.repository.MonthlySettlementHistoryRepository;
+import com.newbit.user.entity.Mentor;
+import com.newbit.user.service.MentorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MentorSettlementService {
+
+    private final SaleHistoryRepository saleHistoryRepository;
+    private final MonthlySettlementHistoryRepository monthlySettlementHistoryRepository;
+    private final MentorService mentorService;
+
+    @Transactional
+    public void generateMonthlySettlements(int year, int month) {
+        // 해당 월의 시작과 끝
+        LocalDateTime start = LocalDate.of(year, month, 1).atStartOfDay();
+        LocalDateTime end = start.plusMonths(1).minusNanos(1);
+
+        // 아직 정산되지 않은 판매 내역 가져오기
+        List<SaleHistory> unsettledSales = saleHistoryRepository
+                .findAllByIsSettledFalseAndCreatedAtBetween(start, end);
+
+        // 멘토별로 그룹화하여 정산금액 계산
+        Map<Long, List<SaleHistory>> groupedByMentor = new HashMap<>();
+        for (SaleHistory sale : unsettledSales) {
+            groupedByMentor.computeIfAbsent(sale.getMentorId(), k -> new ArrayList<>()).add(sale);
+        }
+
+        for (Map.Entry<Long, List<SaleHistory>> entry : groupedByMentor.entrySet()) {
+            Long mentorId = entry.getKey();
+            List<SaleHistory> sales = entry.getValue();
+
+            BigDecimal totalAmount = sales.stream()
+                    .map(SaleHistory::getSaleAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            Mentor mentor = mentorService.getMentorEntityByUserId(mentorId);
+
+            MonthlySettlementHistory settlement = MonthlySettlementHistory.of(mentor, year, month, totalAmount);
+            monthlySettlementHistoryRepository.save(settlement);
+
+            // 해당 판매내역 정산처리
+            sales.forEach(SaleHistory::markAsSettled);
+        }
+    }
+}

--- a/src/test/java/com/newbit/settlement/service/MentorSettlementServiceTest.java
+++ b/src/test/java/com/newbit/settlement/service/MentorSettlementServiceTest.java
@@ -1,0 +1,73 @@
+package com.newbit.settlement.service;
+
+import com.newbit.purchase.command.domain.aggregate.SaleHistory;
+import com.newbit.purchase.command.domain.repository.SaleHistoryRepository;
+import com.newbit.settlement.entity.MonthlySettlementHistory;
+import com.newbit.settlement.repository.MonthlySettlementHistoryRepository;
+import com.newbit.user.entity.Mentor;
+import com.newbit.user.service.MentorService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class MentorSettlementServiceTest {
+
+    @Mock
+    private SaleHistoryRepository saleHistoryRepository;
+
+    @Mock
+    private MonthlySettlementHistoryRepository monthlySettlementHistoryRepository;
+
+    @Mock
+    private MentorService mentorService;
+
+    @InjectMocks
+    private MentorSettlementService settlementService;
+
+    @Test
+    @DisplayName("멘토 정산 생성 - 성공")
+    void generateMonthlySettlements_success() {
+        // given
+        int year = 2025;
+        int month = 4;
+        Long mentorId = 1L;
+
+        SaleHistory sale1 = mock(SaleHistory.class);
+        SaleHistory sale2 = mock(SaleHistory.class);
+        when(sale1.getMentorId()).thenReturn(mentorId);
+        when(sale2.getMentorId()).thenReturn(mentorId);
+        when(sale1.getSaleAmount()).thenReturn(BigDecimal.valueOf(5000));
+        when(sale2.getSaleAmount()).thenReturn(BigDecimal.valueOf(3000));
+
+        SaleHistory sale = mock(SaleHistory.class);
+        List<SaleHistory> sales = List.of(sale1, sale2);
+        when(saleHistoryRepository.findAllByIsSettledFalseAndCreatedAtBetween(any(), any()))
+                .thenReturn(sales);
+
+        Mentor mentor = Mentor.builder().mentorId(mentorId).build();
+        when(mentorService.getMentorEntityByUserId(mentorId)).thenReturn(mentor);
+
+        // when
+        settlementService.generateMonthlySettlements(year, month);
+
+        // then
+        verify(monthlySettlementHistoryRepository, times(1))
+                .save(any(MonthlySettlementHistory.class));
+
+
+        verify(sale1).markAsSettled();
+        verify(sale2).markAsSettled();
+
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
Nbt 185 정산 내역 계산 및 생성 기능 구현	

### 🪐 작업 내용
- 월별 미정산 SaleHistory를 기준으로 멘토별 정산 내역 계산
- 멘토별 총 판매 금액을 집계하여 MonthlySettlementHistory 생성 및 저장
- 해당 SaleHistory 항목들을 정산 완료 상태로 변경 (markAsSettled())
- 입력된 year, month 기준으로 정산 대상 기간 산출
- saleHistoryRepository.findAllByIsSettledFalseAndCreatedAtBetween() 호출로 미정산 내역 조회
- 멘토 ID 기준으로 그룹핑 → 멘토별 총합 계산
- MonthlySettlementHistory.of 로 정산 엔티티 생성 후 저장
- 정산 처리된 SaleHistory는 markAsSettled() 호출로 상태 업데이트