### PR TITLE
[BE] NBT-211 커피챗 관련 알림 발송 처리

### DIFF
--- a/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
+++ b/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
@@ -60,7 +60,7 @@ public class CoffeechatCommandService {
         // 3. 커피챗 요청 등록(서비스 함수 생성)
         createRequestTime(coffeechat.getCoffeechatId(), request.getRequestTimes(), request.getPurchaseQuantity());
 
-
+        // 4. 커피챗 요청 등록시 멘토에게 실시간 알림 발송
         notificationCommandService.sendNotification(
                new NotificationSendRequest(
                        mentorService.getUserIdByMentorId(request.getMentorId())
@@ -121,7 +121,15 @@ public class CoffeechatCommandService {
         // 5. 해당 객체들 삭제
         requests.forEach(req -> requestTimeRepository.deleteById(req.getRequestTimeId()));
 
-        // 6. TODO : 멘티에게 승인 알림 보내주기
+        // 6. 멘티에게 승인 알림 보내주기
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        coffeechat.getMenteeId()
+                        , 4L
+                        , coffeechat.getCoffeechatId()
+                        , "커피챗 요청이 승인되었습니다."
+                )
+        );
     }
 
     @Transactional
@@ -139,7 +147,15 @@ public class CoffeechatCommandService {
         // 4. 해당 객체들 삭제
         requests.forEach(req -> requestTimeRepository.deleteById(req.getRequestTimeId()));
 
-        // 5. TODO : 멘토에게 거절 알림 보내주기
+        // 5. 멘토에게 거절 알림 보내주기
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        coffeechat.getMenteeId()
+                        , 5L
+                        , coffeechat.getCoffeechatId()
+                        , "커피챗 요청이 거절되었습니다."
+                )
+        );
     }
 
     @Transactional

--- a/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
+++ b/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
@@ -210,5 +210,15 @@ public class CoffeechatCommandService {
 
         // 5. 커피챗 객체 업데이트하기
         coffeechat.cancelCoffeechat(coffeechatCancelRequest.getCancelReasonId());
+
+        // 6. 멘토에게 커피챗 취소 알림
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        mentorService.getUserIdByMentorId(coffeechat.getMentorId())
+                        , 6L
+                        , coffeechat.getCoffeechatId()
+                        , "진행 예정인 커피챗이 취소되었습니다."
+                )
+        );
     }
 }

--- a/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
+++ b/src/main/java/com/newbit/coffeechat/command/application/service/CoffeechatCommandService.java
@@ -12,8 +12,11 @@ import com.newbit.coffeechat.query.service.CoffeechatQueryService;
 import com.newbit.coffeechat.query.dto.response.ProgressStatus;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.purchase.command.application.service.DiamondCoffeechatTransactionCommandService;
 import com.newbit.user.dto.response.MentorDTO;
+import com.newbit.user.entity.Mentor;
 import com.newbit.user.service.MentorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +34,7 @@ public class CoffeechatCommandService {
     private final RequestTimeRepository requestTimeRepository;
     private final MentorService mentorService;
     private final DiamondCoffeechatTransactionCommandService transactionCommandService;
+    private final NotificationCommandService notificationCommandService;
 
     /**
      * 한두 번만 사용하는 간단한 조회여서 과도한 추상화를 피하기 위해
@@ -55,6 +59,16 @@ public class CoffeechatCommandService {
 
         // 3. 커피챗 요청 등록(서비스 함수 생성)
         createRequestTime(coffeechat.getCoffeechatId(), request.getRequestTimes(), request.getPurchaseQuantity());
+
+
+        notificationCommandService.sendNotification(
+               new NotificationSendRequest(
+                       mentorService.getUserIdByMentorId(request.getMentorId())
+                       , 3L
+                       , coffeechat.getCoffeechatId()
+                       , "새로운 커피챗 신청이 도착했습니다."
+               )
+        );
 
         return coffeechat.getCoffeechatId();
     }

--- a/src/main/java/com/newbit/coffeeletter/service/MessageServiceImpl.java
+++ b/src/main/java/com/newbit/coffeeletter/service/MessageServiceImpl.java
@@ -92,7 +92,7 @@ public class MessageServiceImpl implements MessageService {
                 new NotificationSendRequest(
                         receiverId,
                         8L,
-                        Long.parseLong(room.getId()),
+                        room.getCoffeeChatId(),
                         message.getContent()
                 )
         );

--- a/src/main/java/com/newbit/notification/command/application/dto/response/NotificationSendResponse.java
+++ b/src/main/java/com/newbit/notification/command/application/dto/response/NotificationSendResponse.java
@@ -34,6 +34,7 @@ public class NotificationSendResponse {
         return NotificationSendResponse.builder()
                 .notificationId(notification.getNotificationId())
                 .content(notification.getContent())
+                .serviceId(notification.getServiceId())
                 .typeName(notification.getNotificationType().getName())
                 .isRead(notification.getIsRead())
                 .createdAt(notification.getCreatedAt())

--- a/src/test/java/com/newbit/coffeeletter/service/MessageServiceTest.java
+++ b/src/test/java/com/newbit/coffeeletter/service/MessageServiceTest.java
@@ -9,6 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.newbit.notification.command.application.service.NotificationCommandService;
+import com.newbit.user.service.MentorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +60,12 @@ class MessageServiceTest {
 
     @Mock
     private ModelMapper modelMapper;
+
+    @Mock
+    private MentorService mentorService;
+
+    @Mock
+    private NotificationCommandService notificationCommandService;
 
     @InjectMocks
     private MessageServiceImpl messageService;
@@ -109,13 +118,24 @@ class MessageServiceTest {
     @Test
     void sendMessage_멘토가_보낸_메시지_성공() {
         // given
-        String roomId = "test-room-id";
+        String roomId = "123";
         Long mentorId = 1L;
-        
+        Long menteeId = 2L;
+
+        messageDTO.setRoomId(roomId);
         messageDTO.setSenderId(mentorId);
-        message.setSenderId(mentorId);
-        message.setReadByMentor(true);
-        message.setReadByMentee(false);
+        message.setSenderId(menteeId);
+        message.setRoomId(roomId);
+        message.setReadByMentor(false);
+        message.setReadByMentee(true);
+
+        CoffeeLetterRoom room = CoffeeLetterRoom.builder()
+                .id(roomId)
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .unreadCountMentor(0)
+                .unreadCountMentee(0)
+                .build();
         
         try (MockedStatic<RoomUtils> mockedRoomUtils = Mockito.mockStatic(RoomUtils.class)) {
             mockedRoomUtils.when(() -> RoomUtils.getRoomById(roomRepository, roomId)).thenReturn(room);
@@ -140,13 +160,25 @@ class MessageServiceTest {
     @Test
     void sendMessage_멘티가_보낸_메시지_성공() {
         // given
-        String roomId = "test-room-id";
+        String roomId = "123";
+        Long mentorId = 1L;
         Long menteeId = 2L;
-        
+
+        messageDTO.setRoomId(roomId);
         messageDTO.setSenderId(menteeId);
+
         message.setSenderId(menteeId);
+        message.setRoomId(roomId);
         message.setReadByMentor(false);
         message.setReadByMentee(true);
+
+        CoffeeLetterRoom room = CoffeeLetterRoom.builder()
+                .id(roomId)
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .unreadCountMentor(0)
+                .unreadCountMentee(0)
+                .build();
         
         try (MockedStatic<RoomUtils> mockedRoomUtils = Mockito.mockStatic(RoomUtils.class)) {
             mockedRoomUtils.when(() -> RoomUtils.getRoomById(roomRepository, roomId)).thenReturn(room);


### PR DESCRIPTION
### 🛰️ Issue
NBT-211 커피챗 관련 알림 발송 처리(#330)

### 🪐 작업 내용
- 멘티가 커피챗 신청했을 시 멘토에게 알림이 실시간으로 발송되도록 한다.
- 멘토가 요청 거부 시 멘티에게 취소 알림이 실시간으로 발송되도록 한다.
- 멘토와 커피챗 일정 확정 시 멘티에게 알림이 실시간으로 발송되도록 한다.
- 멘티가 커피챗 취소시 멘토에게 알림이 실시간으로 발송되도록 한다.
- 새로운 커피레터 발송시에 실시간으로 알림이 발송되도록 한다.
- 코드 변경에 따른 테스트 코드 수정

<img width="1131" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/e944a75b-2a06-418a-9ef4-091b1a8eebf4" />
￼
<img width="1139" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/0eca581c-8d1c-4d0c-8cae-3df7551dd1e9" />



### 추후 고려 사항
- 커피레터 발송시 알림 발송에 대한 테스트 필요

### ✅ Check List (선택)
- [x] 테스트 코드 정상 실행
- [x] Postman을 사용해 알림 발송 확인
