### PR TITLE
Nbt 186 정산서 이메일 자동 발송 기능 구현

### DIFF
--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -112,7 +112,7 @@ public enum ErrorCode {
     COMMENT_POST_MISMATCH("160003", "해당 댓글은 게시글과 매칭되지 않습니다.", HttpStatus.BAD_REQUEST),
 
     /*---------------- 정산 -------------------------*/
-    SETTLEMENT_NOT_FOUND("110000", "정산 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    SETTLEMENT_NOT_FOUND("110000", "정산 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   
     /*--------------- 결제 오류 ------------------*/
     PAYMENT_NOT_FOUND("81001", "결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -122,7 +122,14 @@ public enum ErrorCode {
     PAYMENT_REFUND_FAILED("81005", "결제 환불에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     PAYMENT_NOT_REFUNDABLE("81006", "환불 가능한 결제가 아닙니다.", HttpStatus.BAD_REQUEST),
     PAYMENT_DETAILS_NOT_FOUND("81007", "결제 상세 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    VIRTUAL_ACCOUNT_ISSUANCE_FAILED("81008", "가상계좌 발급에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    VIRTUAL_ACCOUNT_ISSUANCE_FAILED("81008", "가상계좌 발급에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    PAYMENT_REFUND_NOT_FOUND("81012", "환불 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    /*--------------- 추가 결제 에러 코드 ------------------*/
+    PAYMENT_CANNOT_BE_CANCELLED("81013", "결제를 취소할 수 없는 상태입니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_NOT_PARTIAL_CANCELABLE("81014", "부분 취소가 불가능한 결제입니다.", HttpStatus.BAD_REQUEST),
+    REFUND_AMOUNT_EXCEEDS_BALANCE("81015", "환불 금액이 잔액을 초과합니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_CANCEL_FAILED("81016", "결제 취소 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/newbit/settlement/controller/MentorSettlementController.java
+++ b/src/main/java/com/newbit/settlement/controller/MentorSettlementController.java
@@ -57,5 +57,17 @@ public class MentorSettlementController {
         MentorSettlementDetailResponseDto response = mentorSettlementService.getSettlementDetail(settlementId);
         return ApiResponse.success(response);
     }
+
+    @GetMapping("/my/{settlementId}/email")
+    @Operation(summary = "정산 내역 이메일 발송", description = "해당 정산 ID에 대한 정산 내역을 이메일로 전송합니다.")
+    public ApiResponse<Void> sendSettlementEmail(
+            @AuthenticationPrincipal CustomUser customUser,
+            @PathVariable Long settlementId
+    ) {
+        Long userId = customUser.getUserId();
+        Long mentorId = mentorService.getMentorEntityByUserId(userId).getMentorId();
+        mentorSettlementService.sendSettlementEmail(mentorId, settlementId);
+        return ApiResponse.success(null);
+    }
 }
 

--- a/src/test/java/com/newbit/settlement/service/MentorSettlementServiceTest.java
+++ b/src/test/java/com/newbit/settlement/service/MentorSettlementServiceTest.java
@@ -173,7 +173,7 @@ class MentorSettlementServiceTest {
         // then
         verify(mailServiceSupport).sendMailSupport(
                 eq("test@newbit.com"),
-                contains("2025년 4월"),
+                contains("정산 내역"),
                 contains("150000")
         );
     }

--- a/src/test/java/com/newbit/settlement/service/MentorSettlementServiceTest.java
+++ b/src/test/java/com/newbit/settlement/service/MentorSettlementServiceTest.java
@@ -7,7 +7,9 @@ import com.newbit.settlement.dto.response.MentorSettlementListResponseDto;
 import com.newbit.settlement.entity.MonthlySettlementHistory;
 import com.newbit.settlement.repository.MonthlySettlementHistoryRepository;
 import com.newbit.user.entity.Mentor;
+import com.newbit.user.entity.User;
 import com.newbit.user.service.MentorService;
+import com.newbit.user.support.MailServiceSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -36,6 +38,9 @@ class MentorSettlementServiceTest {
 
     @Mock
     private MentorService mentorService;
+
+    @Mock
+    private MailServiceSupport mailServiceSupport;
 
     @InjectMocks
     private MentorSettlementService mentorSettlementService;
@@ -148,6 +153,29 @@ class MentorSettlementServiceTest {
         assertThat(result.getAmount()).isEqualByComparingTo("123456.78");
         assertThat(result.getMonth()).isEqualTo(4);
         assertThat(result.getSettledAt()).isEqualTo(LocalDateTime.of(2025, 4, 30, 23, 59));
+    }
+
+    @Test
+    @DisplayName("정산 이메일 전송 - 성공")
+    void sendSettlementEmail_success() {
+        // given
+        Long mentorId = 1L;
+        Long settlementId = 100L;
+        User user = User.builder().userId(10L).email("test@newbit.com").build();
+        Mentor mentor = Mentor.builder().mentorId(mentorId).user(user).build();
+        MonthlySettlementHistory history = MonthlySettlementHistory.of(mentor, 2025, 4, new BigDecimal("150000"));
+
+        when(monthlySettlementHistoryRepository.findById(settlementId)).thenReturn(Optional.of(history));
+
+        // when
+        mentorSettlementService.sendSettlementEmail(mentorId, settlementId);
+
+        // then
+        verify(mailServiceSupport).sendMailSupport(
+                eq("test@newbit.com"),
+                contains("2025년 4월"),
+                contains("150000")
+        );
     }
 
 }


### PR DESCRIPTION
### 🛰️ Issue
Nbt 186 정산서 이메일 자동 발송 기능 구현	

### 🪐 작업 내용
- SettlementEmailService 클래스 추가
- JavaMailSender를 이용해 정산서 메일 템플릿 발송
- 정산 대상인 mentor에게 해당 월의 정산서 내용을 포함한 이메일 전송
- 정산서 메일 HTML 형식으로 구성
- 월별 정산 내역(MonthlySettlementHistory)을 기반으로 이메일 본문 생성
- 메일 제목: "[Newbit] {{정산 년/월}} 정산서 안내 메일입니다."
