### PR TITLE
[BE] NBT-217 다이아몬드 거래 발생시 알림 발송 기능 구현

### DIFF
--- a/src/main/java/com/newbit/payment/command/application/service/RefundCommandService.java
+++ b/src/main/java/com/newbit/payment/command/application/service/RefundCommandService.java
@@ -2,6 +2,8 @@ package com.newbit.payment.command.application.service;
 
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.payment.command.application.dto.TossPaymentApiDto;
 import com.newbit.payment.command.application.dto.response.PaymentRefundResponse;
 import com.newbit.payment.command.domain.aggregate.Payment;
@@ -20,12 +22,14 @@ import java.util.stream.Collectors;
 public class RefundCommandService extends AbstractPaymentService<PaymentRefundResponse> {
 
     private final RefundRepository refundRepository;
+    private final NotificationCommandService notificationCommandService;
 
     public RefundCommandService(PaymentRepository paymentRepository,
-                               RefundRepository refundRepository,
-                               TossPaymentApiClient tossPaymentApiClient) {
+                                RefundRepository refundRepository,
+                                TossPaymentApiClient tossPaymentApiClient, NotificationCommandService notificationCommandService) {
         super(paymentRepository, tossPaymentApiClient);
         this.refundRepository = refundRepository;
+        this.notificationCommandService = notificationCommandService;
     }
 
     @Transactional
@@ -51,6 +55,17 @@ public class RefundCommandService extends AbstractPaymentService<PaymentRefundRe
         );
         
         Refund savedRefund = refundRepository.save(refund);
+
+        String notificationContent = String.format("환불이 완료되었습니다. (환불금액 : %,d)", savedRefund.getAmount().intValue());
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        payment.getUserId()
+                        , 15L
+                        , savedRefund.getRefundId()
+                        , notificationContent
+                )
+        );
         
         return createRefundResponse(savedRefund);
     }
@@ -81,6 +96,17 @@ public class RefundCommandService extends AbstractPaymentService<PaymentRefundRe
         );
         
         Refund savedRefund = refundRepository.save(refund);
+
+        String notificationContent = String.format("환불이 완료되었습니다. (환불금액 : %,d)", savedRefund.getAmount().intValue());
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        payment.getUserId()
+                        , 15L
+                        , savedRefund.getRefundId()
+                        , notificationContent
+                )
+        );
 
         return createRefundResponse(savedRefund);
     }

--- a/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/PurchaseCommandService.java
@@ -6,6 +6,8 @@ import com.newbit.coffeechat.query.service.CoffeechatQueryService;
 import com.newbit.column.service.ColumnRequestService;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.purchase.command.application.dto.CoffeeChatPurchaseRequest;
 import com.newbit.purchase.command.application.dto.ColumnPurchaseRequest;
 import com.newbit.purchase.command.application.dto.MentorAuthorityPurchaseRequest;
@@ -34,6 +36,7 @@ public class PurchaseCommandService {
     private final UserService userService;
     private final CoffeechatQueryService coffeechatQueryService;
     private final MentorService mentorService;
+    private final NotificationCommandService notificationCommandService;
 
 
 
@@ -78,6 +81,16 @@ public class PurchaseCommandService {
         // 8. 판매 내역 저장
         SaleHistory saleHistory = SaleHistory.forColumn(columnId, columnPrice, mentorId);
         saleHistoryRepository.save(saleHistory);
+
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        userId,
+                        13L,
+                        columnId,
+                        "칼럼 구매가 완료되었습니다."
+                )
+        );
     }
 
 
@@ -111,6 +124,15 @@ public class PurchaseCommandService {
 
         // 3. 다이아 내역 저장
         diamondHistoryRepository.save(DiamondHistory.forCoffeechatPurchase(menteeId, coffeechatId, totalPrice, balance));
+
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        userId,
+                        13L,
+                        coffeechatId,
+                        "커피챗 구매가 완료되었습니다."
+                )
+        );
     }
 
 
@@ -145,5 +167,16 @@ public class PurchaseCommandService {
 
         // 4. 멘토 등록
         mentorService.createMentor(userId);
+
+        if(assetType == PurchaseAssetType.DIAMOND){
+            notificationCommandService.sendNotification(
+                    new NotificationSendRequest(
+                            userId,
+                            13L,
+                            null,
+                            "멘토 권한 구매가 완료되었습니다."
+                    )
+            );
+        }
     }
 }

--- a/src/test/java/com/newbit/payment/command/application/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/newbit/payment/command/application/service/PaymentCommandServiceTest.java
@@ -1,6 +1,7 @@
 package com.newbit.payment.command.application.service;
 
 import com.newbit.common.exception.BusinessException;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.payment.command.application.dto.TossPaymentApiDto;
 import com.newbit.payment.command.application.dto.request.PaymentApproveRequest;
 import com.newbit.payment.command.application.dto.request.PaymentPrepareRequest;
@@ -36,6 +37,9 @@ class PaymentCommandServiceTest {
 
     @Mock
     private TossPaymentApiClient tossPaymentApiClient;
+
+    @Mock
+    private NotificationCommandService notificationCommandService;
 
     @InjectMocks
     private PaymentCommandService paymentCommandService;

--- a/src/test/java/com/newbit/payment/command/application/service/RefundCommandServiceTest.java
+++ b/src/test/java/com/newbit/payment/command/application/service/RefundCommandServiceTest.java
@@ -1,6 +1,7 @@
 package com.newbit.payment.command.application.service;
 
 import com.newbit.common.exception.BusinessException;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.payment.command.application.dto.TossPaymentApiDto;
 import com.newbit.payment.command.application.dto.response.PaymentRefundResponse;
 import com.newbit.payment.command.domain.aggregate.Payment;
@@ -48,6 +49,9 @@ class RefundCommandServiceTest {
 
     @Mock
     private TossPaymentApiClient tossPaymentApiClient;
+
+    @Mock
+    private NotificationCommandService notificationCommandService;
 
     @InjectMocks
     private RefundCommandService refundCommandService;

--- a/src/test/java/com/newbit/purchase/command/application/service/PurchaseCommandServiceTest.java
+++ b/src/test/java/com/newbit/purchase/command/application/service/PurchaseCommandServiceTest.java
@@ -7,6 +7,7 @@ import com.newbit.coffeechat.query.service.CoffeechatQueryService;
 import com.newbit.column.service.ColumnRequestService;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
+import com.newbit.notification.command.application.service.NotificationCommandService;
 import com.newbit.purchase.command.application.dto.CoffeeChatPurchaseRequest;
 import com.newbit.purchase.command.application.dto.ColumnPurchaseRequest;
 import com.newbit.purchase.command.application.dto.MentorAuthorityPurchaseRequest;
@@ -60,6 +61,8 @@ class PurchaseCommandServiceTest {
     private CoffeechatCommandService coffeechatCommandService;
     @Mock
     private PointTypeRepository pointTypeRepository;
+    @Mock
+    private NotificationCommandService notificationCommandService;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
### 🛰️ Issue
NBT-217 다이아몬드 거래 발생시 알림 발송 기능 구현 (#346)

### 🪐 작업 내용
 - 다이아몬드 충전, 전체 환불, 부분 환불시 사용자에게 알림 발송
 - 다이아몬드로 커피챗, 멘토권한, 칼럼 구매시 구매자에게 알림 발송
 - 코드 수정에 따른 테스트 코드 수정

### ✅ Check List (선택)
- [x] 테스트 코드 성공
