### PR TITLE
[BE] NBT-219 다이아 결제 후 회원 다이아 변경 다이아 내역 생성 구현

### DIFF
--- a/src/main/java/com/newbit/payment/command/application/service/RefundCommandService.java
+++ b/src/main/java/com/newbit/payment/command/application/service/RefundCommandService.java
@@ -65,11 +65,11 @@ public class RefundCommandService extends AbstractPaymentService<PaymentRefundRe
 
         String notificationContent = String.format("환불이 완료되었습니다. (환불금액 : %,d)", savedRefund.getAmount().intValue());
 
-        int refundAmount = savedRefund.getAmount().intValue() / DIAMOND_UNIT_PRICE;
+        int refundDiamondAmount = savedRefund.getAmount().intValue() / DIAMOND_UNIT_PRICE;
         diamondTransactionCommandService.applyDiamondRefund(
                 payment.getUserId(),
                 savedRefund.getRefundId(),
-                refundAmount
+                refundDiamondAmount
         );
 
         notificationCommandService.sendNotification(
@@ -111,8 +111,14 @@ public class RefundCommandService extends AbstractPaymentService<PaymentRefundRe
         
         Refund savedRefund = refundRepository.save(refund);
 
-        String notificationContent = String.format("환불이 완료되었습니다. (환불금액 : %,d)", savedRefund.getAmount().intValue());
+        int refundDiamondAmount = savedRefund.getAmount().intValue() / DIAMOND_UNIT_PRICE;
+        diamondTransactionCommandService.applyDiamondRefund(
+                payment.getUserId(),
+                savedRefund.getRefundId(),
+                refundDiamondAmount
+        );
 
+        String notificationContent = String.format("환불이 완료되었습니다. (환불금액 : %,d)", savedRefund.getAmount().intValue());
 
 
         notificationCommandService.sendNotification(

--- a/src/main/java/com/newbit/purchase/command/application/service/DiamondCoffeechatTransactionCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/DiamondCoffeechatTransactionCommandService.java
@@ -32,4 +32,5 @@ public class DiamondCoffeechatTransactionCommandService {
         // 2. 다이아 내역 저장
         diamondHistoryRepository.save(DiamondHistory.forCoffeechatRefund(menteeId, coffeechatId, totalPrice, balance));
     }
+
 }

--- a/src/main/java/com/newbit/purchase/command/application/service/DiamondTransactionCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/DiamondTransactionCommandService.java
@@ -15,7 +15,7 @@ public class DiamondTransactionCommandService {
     private final DiamondHistoryRepository diamondHistoryRepository;
     private final UserService userService;
 
-    public void savePointHistory(
+    public void saveDiamondHistory(
             Long userId,
             DiamondTransactionType type,
             Integer increaseAmount,
@@ -35,11 +35,16 @@ public class DiamondTransactionCommandService {
     }
 
 
-
     @Transactional
     public void applyDiamondPayment(Long userId, Long paymentId, Integer amount) {
         Integer balance = userService.addDiamond(userId, amount);
-        savePointHistory(userId, DiamondTransactionType.CHARGE, amount, null, paymentId, balance);
+        saveDiamondHistory(userId, DiamondTransactionType.CHARGE, amount, null, paymentId, balance);
+    }
+
+    @Transactional
+    public void applyDiamondRefund(Long userId, Long refundId, Integer amount) {
+        Integer balance = userService.useDiamond(userId, amount);
+        saveDiamondHistory(userId, DiamondTransactionType.REFUND, null, amount, refundId, balance);
     }
 
 }

--- a/src/main/java/com/newbit/purchase/command/application/service/DiamondTransactionCommandService.java
+++ b/src/main/java/com/newbit/purchase/command/application/service/DiamondTransactionCommandService.java
@@ -1,0 +1,45 @@
+package com.newbit.purchase.command.application.service;
+
+import com.newbit.purchase.command.domain.aggregate.DiamondHistory;
+import com.newbit.purchase.command.domain.aggregate.DiamondTransactionType;
+import com.newbit.purchase.command.domain.repository.DiamondHistoryRepository;
+import com.newbit.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DiamondTransactionCommandService {
+
+    private final DiamondHistoryRepository diamondHistoryRepository;
+    private final UserService userService;
+
+    public void savePointHistory(
+            Long userId,
+            DiamondTransactionType type,
+            Integer increaseAmount,
+            Integer decreaseAmount,
+            Long serviceId,
+            Integer balance
+    ) {
+        DiamondHistory history = DiamondHistory.builder()
+                .userId(userId)
+                .serviceType(type)
+                .serviceId(serviceId)
+                .increaseAmount(increaseAmount)
+                .decreaseAmount(decreaseAmount)
+                .balance(balance)
+                .build();
+        diamondHistoryRepository.save(history);
+    }
+
+
+
+    @Transactional
+    public void applyDiamondPayment(Long userId, Long paymentId, Integer amount) {
+        Integer balance = userService.addDiamond(userId, amount);
+        savePointHistory(userId, DiamondTransactionType.CHARGE, amount, null, paymentId, balance);
+    }
+
+}

--- a/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondTransactionType.java
+++ b/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondTransactionType.java
@@ -3,5 +3,6 @@ package com.newbit.purchase.command.domain.aggregate;
 public enum DiamondTransactionType {
     COLUMN,
     COFFEECHAT,
-    MENTOR_AUTHORITY
+    MENTOR_AUTHORITY,
+    CHARGE
 }

--- a/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondTransactionType.java
+++ b/src/main/java/com/newbit/purchase/command/domain/aggregate/DiamondTransactionType.java
@@ -4,5 +4,6 @@ public enum DiamondTransactionType {
     COLUMN,
     COFFEECHAT,
     MENTOR_AUTHORITY,
-    CHARGE
+    CHARGE,
+    REFUND
 }

--- a/src/test/java/com/newbit/payment/command/application/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/newbit/payment/command/application/service/PaymentCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.newbit.payment.command.domain.aggregate.Payment;
 import com.newbit.payment.command.domain.aggregate.PaymentMethod;
 import com.newbit.payment.command.domain.aggregate.PaymentStatus;
 import com.newbit.payment.command.domain.repository.PaymentRepository;
+import com.newbit.purchase.command.application.service.DiamondTransactionCommandService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,9 @@ class PaymentCommandServiceTest {
 
     @Mock
     private NotificationCommandService notificationCommandService;
+
+    @Mock
+    private DiamondTransactionCommandService diamondTransactionCommandService;
 
     @InjectMocks
     private PaymentCommandService paymentCommandService;

--- a/src/test/java/com/newbit/payment/command/application/service/RefundCommandServiceTest.java
+++ b/src/test/java/com/newbit/payment/command/application/service/RefundCommandServiceTest.java
@@ -10,6 +10,7 @@ import com.newbit.payment.command.domain.aggregate.PaymentStatus;
 import com.newbit.payment.command.domain.aggregate.Refund;
 import com.newbit.payment.command.domain.repository.PaymentRepository;
 import com.newbit.payment.command.domain.repository.RefundRepository;
+import com.newbit.purchase.command.application.service.DiamondTransactionCommandService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,9 @@ class RefundCommandServiceTest {
 
     @Mock
     private NotificationCommandService notificationCommandService;
+
+    @Mock
+    private DiamondTransactionCommandService diamondTransactionCommandService;
 
     @InjectMocks
     private RefundCommandService refundCommandService;

--- a/src/test/java/com/newbit/purchase/command/application/service/DiamondTransactionCommandServiceTest.java
+++ b/src/test/java/com/newbit/purchase/command/application/service/DiamondTransactionCommandServiceTest.java
@@ -1,0 +1,52 @@
+package com.newbit.purchase.command.application.service;
+
+import com.newbit.purchase.command.domain.aggregate.DiamondHistory;
+import com.newbit.purchase.command.domain.aggregate.DiamondTransactionType;
+import com.newbit.purchase.command.domain.repository.DiamondHistoryRepository;
+import com.newbit.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiamondTransactionCommandServiceTest {
+
+    private DiamondTransactionCommandService diamondTransactionCommandService;
+    private DiamondHistoryRepository diamondHistoryRepository;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        diamondHistoryRepository = mock(DiamondHistoryRepository.class);
+        userService = mock(UserService.class);
+        diamondTransactionCommandService = new DiamondTransactionCommandService(diamondHistoryRepository, userService);
+    }
+
+    @Test
+    void applyDiamondPayment_success() {
+        // given
+        Long userId = 1L;
+        Long paymentId = 100L;
+        Integer amount = 5000;
+        Integer updatedBalance = 8000;
+
+        when(userService.addDiamond(userId, amount)).thenReturn(updatedBalance);
+
+        // when
+        diamondTransactionCommandService.applyDiamondPayment(userId, paymentId, amount);
+
+        // then
+        ArgumentCaptor<DiamondHistory> captor = ArgumentCaptor.forClass(DiamondHistory.class);
+        verify(diamondHistoryRepository, times(1)).save(captor.capture());
+
+        DiamondHistory saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(userId);
+        assertThat(saved.getServiceType()).isEqualTo(DiamondTransactionType.CHARGE);
+        assertThat(saved.getServiceId()).isEqualTo(paymentId);
+        assertThat(saved.getIncreaseAmount()).isEqualTo(amount);
+        assertThat(saved.getDecreaseAmount()).isNull();
+        assertThat(saved.getBalance()).isEqualTo(updatedBalance);
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
NBT-219 다이아 결제 후 회원 다이아 변경 다이아 내역 생성 구현(#349)

### 🪐 작업 내용
- 다이아 결제/환불 후 회원의 보유 다이아가 증감 되도록 구현 (구매 도메인)
- 다이아 결제/환불 후 다이아 내역이 생성되도록 구현 (구매 도메인)
- 결제 후 구매 도메인에 구현된 메서드를 호출하도록 구현 (결제 도메인)
- 전체 환불 후 구매 도메인에 구현된 메서드를 호출하도록 구현 (결제 도메인)
- 부분 환불 후 구매 도메인에 구현된 메서드를 호출하도록 구현 (결제 도메인)
- 코드 수정에 대한 테스트 코드 수정
 

### ✅ Check List (선택)
- [x] 단위 테스트 코드 작성
- [x] 수정한 단위 테스트 코드 성공
