### PR TITLE
fix: 비회원 게시글 등록 시 NullPointerException 발생 문제 해결

### DIFF
--- a/src/main/java/com/newbit/common/exception/ErrorCode.java
+++ b/src/main/java/com/newbit/common/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
     //게시글
     POST_NOT_FOUND("20001", "해당 게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     UNAUTHORIZED_TO_UPDATE_POST("20002", "게시글은 작성자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
-    ONLY_USER_CAN_CREATE_POST("20003", "게시글은 일반 사용자만 작성할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ONLY_USER_CAN_CREATE_POST("20003", "게시글은 회원만 작성할 수 있습니다.", HttpStatus.FORBIDDEN),
     UNAUTHORIZED_TO_DELETE_POST("20004", "게시글은 작성자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
     ONLY_ADMIN_CAN_CREATE_NOTICE("20005", "공지사항은 관리자만 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
     ONLY_ADMIN_CAN_UPDATE_NOTICE("20006", "공지사항은 관리자만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/newbit/post/service/PostService.java
+++ b/src/main/java/com/newbit/post/service/PostService.java
@@ -44,6 +44,10 @@ public class PostService {
 
     @Transactional
     public PostResponse createPost(PostCreateRequest request, CustomUser user) {
+        if (user == null) {
+            throw new BusinessException(ErrorCode.ONLY_USER_CAN_CREATE_POST);
+        }
+
         boolean isUser = user.getAuthorities().stream()
                 .anyMatch(auth -> "ROLE_USER".equals(auth.getAuthority()));
 

--- a/src/test/java/com/newbit/post/service/PostServiceTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceTest.java
@@ -129,7 +129,7 @@ class PostServiceTest {
     }
 
     @Test
-    void 게시글_등록_성공_일반사용자() {
+    void 게시글_등록_성공_회원() {
         // given
         CustomUser user = CustomUser.builder()
                 .userId(1L)

--- a/src/test/java/com/newbit/post/service/PostServiceTest.java
+++ b/src/test/java/com/newbit/post/service/PostServiceTest.java
@@ -155,27 +155,23 @@ class PostServiceTest {
     }
 
     @Test
-    void 게시글_등록_실패_관리자() {
+    void 게시글_등록_실패_비회원() {
         // given
-        CustomUser adminUser = CustomUser.builder()
-                .userId(2L)
-                .email("admin@example.com")
-                .password("encoded")
-                .authorities(List.of(new SimpleGrantedAuthority("ROLE_ADMIN")))
-                .build();
+        PostCreateRequest request = new PostCreateRequest();
+        request.setTitle("비회원 테스트");
+        request.setContent("비회원은 작성 못함");
+        request.setPostCategoryId(1L);
 
-        PostCreateRequest adminRequest = new PostCreateRequest();
-        adminRequest.setTitle("관리자 글");
-        adminRequest.setContent("관리자가 작성한 글");
-        adminRequest.setPostCategoryId(1L);
+        CustomUser unauthenticatedUser = null;
 
         // when & then
-        assertThatThrownBy(() -> postService.createPost(adminRequest, adminUser))
+        assertThatThrownBy(() -> postService.createPost(request, unauthenticatedUser))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.ONLY_USER_CAN_CREATE_POST.getMessage());
 
         verify(postRepository, never()).save(any(Post.class));
     }
+
 
     @Test
     void 게시글_삭제_성공() {


### PR DESCRIPTION
### 🛰️ Issue
close #363 

### 🪐 작업 내용
비회원의 게시글 등록 시 NullPointerException 발생 문제 해결
비회원일 경우 BusinessException을 발생시키고, ErrorCode.ONLY_USER_CAN_CREATE_POST를 반환하도록 통일

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] Swagger API 테스트 
- [x] 단위 테스트 
