### PR TITLE
[BE] NBT-215 시리즈에 새로운 칼럼 등록시 구독한 사용자들에게 알림 발송 기능구현

### DIFF
--- a/src/test/java/com/newbit/column/service/AdminColumnServiceTest.java
+++ b/src/test/java/com/newbit/column/service/AdminColumnServiceTest.java
@@ -2,6 +2,7 @@ package com.newbit.column.service;
 
 import com.newbit.column.domain.Column;
 import com.newbit.column.domain.ColumnRequest;
+import com.newbit.column.domain.Series;
 import com.newbit.column.dto.request.ApproveColumnRequestDto;
 import com.newbit.column.dto.request.RejectColumnRequestDto;
 import com.newbit.column.dto.response.AdminColumnResponseDto;
@@ -11,6 +12,7 @@ import com.newbit.column.repository.ColumnRequestRepository;
 import com.newbit.common.exception.BusinessException;
 import com.newbit.common.exception.ErrorCode;
 import com.newbit.notification.command.application.service.NotificationCommandService;
+import com.newbit.subscription.service.SubscriptionService;
 import com.newbit.user.entity.Mentor;
 import com.newbit.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +46,9 @@ class AdminColumnServiceTest {
     @Mock
     private NotificationCommandService notificationCommandService;
 
+    @Mock
+    private SubscriptionService subscriptionService;
+
     @BeforeEach
     void setUp() {
         // MockitoAnnotations.openMocks(this); // MockitoExtension으로 대체
@@ -60,7 +65,8 @@ class AdminColumnServiceTest {
 
         User user = User.builder().userId(1L).email("mentor@example.com").build();
         Mentor mentor = Mentor.builder().mentorId(10L).user(user).build();
-        Column column = Column.builder().columnId(10L).title("테스트 칼럼").mentor(mentor).build();
+        Series series = Series.builder().seriesId(1L).build();
+        Column column = Column.builder().columnId(10L).title("테스트 칼럼").series(series).mentor(mentor).build();
         ColumnRequest request = ColumnRequest.builder()
                 .columnRequestId(requestId)
                 .requestType(RequestType.CREATE)


### PR DESCRIPTION
### 🛰️ Issue
NBT-215 시리즈에 새로운 칼럼 등록시 구독한 사용자들에게 알림 발송 기능구현

### 🪐 작업 내용
- 시리즈에 새로운 칼럼이 등록이 승인되어 발행될 때 시리즈를 구독한 모든 사용자들에게 실시간 알림을 전송
- 칼럼 등록 승인 테스트 코드 수정
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/0977ee00-dc83-4d7f-9bf4-3bba6f9cbc20" />

### ✅ Check List (선택)
- [x] 단위 테스트 코드 성공 
- [x] Postman에서 알림 정상 수신 확인
