### PR TITLE
[BE] NBT-263 게시판 도메인 포인트 지급 리팩터링

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/CommentInternalService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/CommentInternalService.java
@@ -1,0 +1,39 @@
+package com.newbit.newbitfeatureservice.post.service;
+
+import com.newbit.newbitfeatureservice.common.exception.BusinessException;
+import com.newbit.newbitfeatureservice.common.exception.ErrorCode;
+import com.newbit.newbitfeatureservice.post.dto.request.CommentCreateRequest;
+import com.newbit.newbitfeatureservice.post.entity.Comment;
+import com.newbit.newbitfeatureservice.post.entity.Post;
+import com.newbit.newbitfeatureservice.post.repository.CommentRepository;
+import com.newbit.newbitfeatureservice.post.repository.PostRepository;
+import com.newbit.newbitfeatureservice.security.model.CustomUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentInternalService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+
+    @Transactional
+    protected Comment saveCommentInternal(Long postId, CommentCreateRequest request, CustomUser user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .userId(user.getUserId())
+                .reportCount(0)
+                .post(post)
+                .build();
+
+        commentRepository.save(comment);
+        return comment;
+    }
+
+}

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostInternalService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostInternalService.java
@@ -1,0 +1,38 @@
+package com.newbit.newbitfeatureservice.post.service;
+
+import com.newbit.newbitfeatureservice.common.exception.BusinessException;
+import com.newbit.newbitfeatureservice.common.exception.ErrorCode;
+import com.newbit.newbitfeatureservice.post.dto.request.PostCreateRequest;
+import com.newbit.newbitfeatureservice.post.entity.Post;
+import com.newbit.newbitfeatureservice.post.repository.PostRepository;
+import com.newbit.newbitfeatureservice.security.model.CustomUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostInternalService {
+
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Post createPostInternal(PostCreateRequest request, CustomUser user) {
+        if (user == null || user.getAuthorities().stream()
+                .noneMatch(auth -> "ROLE_USER".equals(auth.getAuthority()))) {
+            throw new BusinessException(ErrorCode.ONLY_USER_CAN_CREATE_POST);
+        }
+
+        Post post = Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .userId(user.getUserId())
+                .postCategoryId(request.getPostCategoryId())
+                .likeCount(0)
+                .reportCount(0)
+                .isNotice(false)
+                .build();
+
+        return postRepository.save(post);
+    }
+}

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostInternalService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostInternalService.java
@@ -18,11 +18,6 @@ public class PostInternalService {
 
     @Transactional
     public Post createPostInternal(PostCreateRequest request, CustomUser user) {
-        if (user == null || user.getAuthorities().stream()
-                .noneMatch(auth -> "ROLE_USER".equals(auth.getAuthority()))) {
-            throw new BusinessException(ErrorCode.ONLY_USER_CAN_CREATE_POST);
-        }
-
         Post post = Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/post/service/PostServiceNoticeTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/post/service/PostServiceNoticeTest.java
@@ -28,14 +28,17 @@ class PostServiceNoticeTest {
     private PointTransactionCommandService pointTransactionCommandService;
     private PostService postService;
     private UserFeignClient userFeignClient;
+    private PostInternalService postInternalService;
 
     @BeforeEach
     void setUp() {
         postRepository = mock(PostRepository.class);
         commentRepository = mock(CommentRepository.class);
         pointTransactionCommandService = mock(PointTransactionCommandService.class);
+        postInternalService = mock(PostInternalService.class);
 
-        postService = new PostService(postRepository, commentRepository, pointTransactionCommandService, userFeignClient);
+
+        postService = new PostService(postRepository, commentRepository, pointTransactionCommandService, userFeignClient, postInternalService);
     }
 
     @Test

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/post/service/PostServiceTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/post/service/PostServiceTest.java
@@ -34,6 +34,7 @@ class PostServiceTest {
     private PostCreateRequest request;
     private CommentRepository commentRepository;
     private UserFeignClient userFeignClient;
+    private PostInternalService postInternalService;
 
     @BeforeEach
     void setUp() {
@@ -41,8 +42,9 @@ class PostServiceTest {
         commentRepository = mock(CommentRepository.class);
         pointTransactionCommandService = mock(PointTransactionCommandService.class);
         userFeignClient = mock(UserFeignClient.class);
+        postInternalService = mock(PostInternalService.class);
 
-        postService = new PostService(postRepository, commentRepository, pointTransactionCommandService, userFeignClient);
+        postService = new PostService(postRepository, commentRepository, pointTransactionCommandService, userFeignClient, postInternalService);
 
         request = new PostCreateRequest();
         request.setTitle("단위 테스트 제목");
@@ -166,7 +168,7 @@ class PostServiceTest {
 
         // PostService를 다시 생성해서 의존성 주입
         PointTransactionCommandService pointTransactionCommandService = mock(PointTransactionCommandService.class);
-        PostService postServiceWithMocks = new PostService(postRepository, commentRepository, pointTransactionCommandService, userFeignClient);
+        PostService postServiceWithMocks = new PostService(postRepository, commentRepository, pointTransactionCommandService, userFeignClient, postInternalService);
 
 
         // when


### PR DESCRIPTION
### 🛰️ Issue
NBT-263 게시판 도메인 포인트 지급 리팩터링 (close #442)

### 🪐 작업 내용
- Comment 관련 사이드 이펙트 처리 Service 분리 (포인트 지급, 알림 발송)
- Post 관련 사이드 이펙트 처리 Service 분리 (포인트 지급, 알림 발송)
- Transaction과 FeignClient 호출 로직 분리
- 테스트 코드 수정

### ✅ Check List (선택)
- [x] API 테스트 완료
- [x] 단위 테스트 성공
