### PR TITLE
feat: Report 도메인 jpa 쿼리 서비스들을 myBatis 동적 쿼리 사용하여 코드 간소화

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/report/query/infrastructure/mapper/ReportMapper.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/report/query/infrastructure/mapper/ReportMapper.java
@@ -1,0 +1,21 @@
+package com.newbit.newbitfeatureservice.report.query.infrastructure.mapper;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Pageable;
+
+import com.newbit.newbitfeatureservice.report.command.domain.aggregate.ReportStatus;
+import com.newbit.newbitfeatureservice.report.query.dto.response.ReportDTO;
+
+@Mapper
+public interface ReportMapper {
+    
+    List<ReportDTO> findReports(Map<String, Object> params);
+    
+    int countReports(Map<String, Object> params);
+    
+    List<ReportDTO> findAllWithoutPaging();
+} 

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/report/query/infrastructure/repository/MyBatisReportQueryRepository.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/report/query/infrastructure/repository/MyBatisReportQueryRepository.java
@@ -1,0 +1,150 @@
+package com.newbit.newbitfeatureservice.report.query.infrastructure.repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.newbit.newbitfeatureservice.report.command.domain.aggregate.ReportStatus;
+import com.newbit.newbitfeatureservice.report.query.domain.repository.ReportQueryRepository;
+import com.newbit.newbitfeatureservice.report.query.dto.response.ReportDTO;
+import com.newbit.newbitfeatureservice.report.query.infrastructure.mapper.ReportMapper;
+
+@Repository
+@Primary
+public class MyBatisReportQueryRepository implements ReportQueryRepository {
+
+    private final ReportMapper reportMapper;
+
+    public MyBatisReportQueryRepository(ReportMapper reportMapper) {
+        this.reportMapper = reportMapper;
+    }
+
+    @Override
+    public List<ReportDTO> findAllWithoutPaging() {
+        return reportMapper.findAllWithoutPaging();
+    }
+
+    @Override
+    public Page<ReportDTO> findReports(ReportStatus status, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("status", status);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByPostId(Long postId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("postId", postId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByCommentId(Long commentId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("commentId", commentId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByReporterId(Long userId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("userId", userId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByReportTypeId(Long reportTypeId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("reportTypeId", reportTypeId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByStatusAndReportTypeId(ReportStatus status, Long reportTypeId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("status", status);
+        params.put("reportTypeId", reportTypeId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByPostUserId(Long userId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("postUserId", userId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByCommentUserId(Long userId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("commentUserId", userId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+
+    @Override
+    public Page<ReportDTO> findReportsByContentUserId(Long userId, Pageable pageable) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("contentUserId", userId);
+        params.put("offset", pageable.getOffset());
+        params.put("pageSize", pageable.getPageSize());
+        
+        List<ReportDTO> reports = reportMapper.findReports(params);
+        int total = reportMapper.countReports(params);
+        
+        return new PageImpl<>(reports, pageable, total);
+    }
+} 

--- a/newbit-feature-service/src/main/resources/mappers/report/ReportMapper.xml
+++ b/newbit-feature-service/src/main/resources/mappers/report/ReportMapper.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.newbit.newbitfeatureservice.report.query.infrastructure.mapper.ReportMapper">
+
+    <resultMap id="reportResultMap" type="com.newbit.newbitfeatureservice.report.query.dto.response.ReportDTO">
+        <id property="reportId" column="report_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="commentId" column="comment_id"/>
+        <result property="postId" column="post_id"/>
+        <result property="content" column="content"/>
+        <result property="status" column="status"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <association property="reportType" javaType="com.newbit.newbitfeatureservice.report.query.dto.response.ReportTypeDTO">
+            <id property="id" column="report_type_id"/>
+            <result property="name" column="report_type_name"/>
+        </association>
+    </resultMap>
+    
+    <sql id="selectClause">
+        SELECT r.id as report_id, 
+               r.user_id, 
+               r.comment_id, 
+               r.post_id, 
+               r.content, 
+               r.status, 
+               r.created_at, 
+               r.updated_at, 
+               rt.id as report_type_id, 
+               rt.name as report_type_name
+        FROM tb_report r
+        JOIN tb_report_type rt ON r.report_type_id = rt.id
+    </sql>
+    
+    <sql id="whereClause">
+        <where>
+            <if test="status != null">
+                AND r.status = #{status}
+            </if>
+            <if test="postId != null">
+                AND r.post_id = #{postId}
+            </if>
+            <if test="commentId != null">
+                AND r.comment_id = #{commentId}
+            </if>
+            <if test="userId != null">
+                AND r.user_id = #{userId}
+            </if>
+            <if test="reportTypeId != null">
+                AND rt.id = #{reportTypeId}
+            </if>
+            <if test="postUserId != null">
+                AND r.post_id IN (SELECT id FROM tb_post WHERE user_id = #{postUserId})
+            </if>
+            <if test="commentUserId != null">
+                AND r.comment_id IN (SELECT id FROM tb_comment WHERE user_id = #{commentUserId})
+            </if>
+            <if test="contentUserId != null">
+                AND (
+                    r.post_id IN (SELECT id FROM tb_post WHERE user_id = #{contentUserId})
+                    OR r.comment_id IN (SELECT id FROM tb_comment WHERE user_id = #{contentUserId})
+                )
+            </if>
+        </where>
+    </sql>
+    
+    <select id="findReports" resultMap="reportResultMap">
+        <include refid="selectClause" />
+        <include refid="whereClause" />
+        ORDER BY r.created_at DESC
+        LIMIT #{offset}, #{pageSize}
+    </select>
+    
+    <select id="countReports" resultType="int">
+        SELECT COUNT(*)
+        FROM tb_report r
+        JOIN tb_report_type rt ON r.report_type_id = rt.id
+        <include refid="whereClause" />
+    </select>
+    
+    <select id="findAllWithoutPaging" resultMap="reportResultMap">
+        <include refid="selectClause" />
+        ORDER BY r.created_at DESC
+    </select>
+
+</mapper> 

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/report/query/infrastructure/repository/MyBatisReportQueryRepositoryTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/report/query/infrastructure/repository/MyBatisReportQueryRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.newbit.newbitfeatureservice.report.query.infrastructure.repository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.ArgumentMatchers.anyMap;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.newbit.newbitfeatureservice.report.command.domain.aggregate.ReportStatus;
+import com.newbit.newbitfeatureservice.report.query.dto.response.ReportDTO;
+import com.newbit.newbitfeatureservice.report.query.infrastructure.mapper.ReportMapper;
+
+@ExtendWith(MockitoExtension.class)
+class MyBatisReportQueryRepositoryTest {
+
+    @Mock
+    private ReportMapper reportMapper;
+
+    @InjectMocks
+    private MyBatisReportQueryRepository repository;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> paramCaptor;
+
+    private List<ReportDTO> mockReports;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        // ReportDTO - 클래스 구조에 맞게 생성 방식 수정 
+        ReportDTO report1 = new ReportDTO();
+        ReportDTO report2 = new ReportDTO();
+        
+        // 페이징 객체 생성
+        pageable = PageRequest.of(0, 10);
+        
+        mockReports = Arrays.asList(report1, report2);
+    }
+
+    @Test
+    @DisplayName("신고 상태별 조회 시 올바른 파라미터가 전달되어야 한다")
+    void findReportsByStatus() {
+        // given
+        when(reportMapper.findReports(anyMap())).thenReturn(mockReports);
+        when(reportMapper.countReports(anyMap())).thenReturn(mockReports.size());
+        
+        // when
+        Page<ReportDTO> result = repository.findReports(ReportStatus.PENDING, pageable);
+        
+        // then
+        verify(reportMapper).findReports(paramCaptor.capture());
+        Map<String, Object> params = paramCaptor.getValue();
+        
+        assertThat(params).containsEntry("status", ReportStatus.PENDING);
+        assertThat(params).containsEntry("offset", 0L);
+        assertThat(params).containsEntry("pageSize", 10);
+        
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+    
+    @Test
+    @DisplayName("게시글 ID로 조회 시 올바른 파라미터가 전달되어야 한다")
+    void findReportsByPostId() {
+        // given
+        when(reportMapper.findReports(anyMap())).thenReturn(mockReports);
+        when(reportMapper.countReports(anyMap())).thenReturn(mockReports.size());
+        
+        // when
+        repository.findReportsByPostId(200L, pageable);
+        
+        // then
+        verify(reportMapper).findReports(paramCaptor.capture());
+        Map<String, Object> params = paramCaptor.getValue();
+        
+        assertThat(params).containsEntry("postId", 200L);
+        assertThat(params).containsEntry("offset", 0L);
+        assertThat(params).containsEntry("pageSize", 10);
+        
+        assertThat(mockReports).hasSize(2);
+    }
+    
+    @Test
+    @DisplayName("신고 상태와 유형으로 조회 시 올바른 파라미터가 전달되어야 한다")
+    void findReportsByStatusAndReportTypeId() {
+        // given
+        when(reportMapper.findReports(anyMap())).thenReturn(mockReports);
+        when(reportMapper.countReports(anyMap())).thenReturn(mockReports.size());
+        
+        // when
+        repository.findReportsByStatusAndReportTypeId(ReportStatus.PENDING, 1L, pageable);
+        
+        // then
+        verify(reportMapper).findReports(paramCaptor.capture());
+        Map<String, Object> params = paramCaptor.getValue();
+        
+        assertThat(params).containsEntry("status", ReportStatus.PENDING);
+        assertThat(params).containsEntry("reportTypeId", 1L);
+        assertThat(params).containsEntry("offset", 0L);
+        assertThat(params).containsEntry("pageSize", 10);
+    }
+    
+    @Test
+    @DisplayName("콘텐츠 작성자 ID로 조회 시 올바른 파라미터가 전달되어야 한다")
+    void findReportsByContentUserId() {
+        // given
+        when(reportMapper.findReports(anyMap())).thenReturn(mockReports);
+        when(reportMapper.countReports(anyMap())).thenReturn(mockReports.size());
+        
+        // when
+        repository.findReportsByContentUserId(500L, pageable);
+        
+        // then
+        verify(reportMapper).findReports(paramCaptor.capture());
+        Map<String, Object> params = paramCaptor.getValue();
+        
+        assertThat(params).containsEntry("contentUserId", 500L);
+        assertThat(params).containsEntry("offset", 0L);
+        assertThat(params).containsEntry("pageSize", 10);
+    }
+} 

--- a/newbit-feature-service/src/test/resources/sql/report-test-data.sql
+++ b/newbit-feature-service/src/test/resources/sql/report-test-data.sql
@@ -1,0 +1,17 @@
+-- 테스트 데이터 초기화
+DELETE FROM tb_report;
+-- DELETE FROM tb_report_type; -- 실제 데이터 사용을 위해 삭제하지 않음
+
+-- 신고 데이터
+INSERT INTO tb_report (id, user_id, post_id, comment_id, report_type_id, content, status, created_at, updated_at) VALUES
+-- 게시글 신고
+(1, 100, 1, NULL, 1, '욕설이 포함된 게시글입니다', 'PENDING', NOW(), NOW()),
+(2, 101, 1, NULL, 2, '불법 콘텐츠가 포함된 게시글입니다', 'PENDING', NOW(), NOW()),
+(3, 102, 2, NULL, 5, '광고성 게시글입니다', 'PROCESSED', NOW(), NOW()),
+-- 댓글 신고
+(4, 100, NULL, 1, 1, '욕설이 포함된 댓글입니다', 'PENDING', NOW(), NOW()),
+(5, 101, NULL, 2, 10, '허위 정보가 포함된 댓글입니다', 'PROCESSED', NOW(), NOW()),
+(6, 102, NULL, 1, 3, '음란물이 포함된 댓글입니다', 'PENDING', NOW(), NOW()),
+-- 여러 조건 조합 테스트용
+(7, 103, 3, NULL, 5, '스팸 게시글입니다', 'PENDING', NOW(), NOW()),
+(8, 104, NULL, 3, 5, '스팸 댓글입니다', 'PENDING', NOW(), NOW()); 


### PR DESCRIPTION
### 🛰️ Issue
Close #457	

### 🪐 작업 내용
- Report 도메인 조회 관련 기능을 Jpa에서 myBatis 동적 쿼리로 변경

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] 단위 테스트
