### PR TITLE
[BE] NBT-277 커피챗 취소 db처리 로직과 외부 서비스 호출로직 분리

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/coffeechat/command/application/service/CoffeechatCommandService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/coffeechat/command/application/service/CoffeechatCommandService.java
@@ -207,7 +207,6 @@ public class CoffeechatCommandService {
         transactionCommandService.addSaleHistory(coffeechat.getMentorId(), totalQuantity, coffeechatId);
     }
 
-    @Transactional
     public void cancelCoffeechat(Long userId, CoffeechatCancelRequest coffeechatCancelRequest, Long coffeechatId) {
         // 1. 커피챗 ID로 커피챗 객체 찾기
         Coffeechat coffeechat = coffeechatRepository.findById(coffeechatId)
@@ -218,33 +217,43 @@ public class CoffeechatCommandService {
             throw new BusinessException(ErrorCode.COFFEECHAT_CANCEL_NOT_ALLOWED);
         }
 
+        ProgressStatus progressStatus = coffeechat.getProgressStatus();
         // 3. 커피챗이 CANCEL 상태이거나, COMPLETE 상태이면 에러
-        switch (coffeechat.getProgressStatus()){
+        switch (progressStatus){
             case CANCEL, COMPLETE -> throw new BusinessException(ErrorCode.INVALID_COFFEECHAT_STATUS_CANCEL);
         }
 
         // 4. 커피챗이 coffeechat_waiting 상태이면 환불 진행하기
-        if(coffeechat.getProgressStatus().equals(ProgressStatus.COFFEECHAT_WAITING)) {
+        if (progressStatus == ProgressStatus.COFFEECHAT_WAITING) {
             MentorDTO mentorDTO = mentorClient.getMentorInfo(coffeechat.getMentorId()).getData();
-            int totalQuantity = mentorDTO.getPrice() * coffeechat.getPurchaseQuantity();
-            transactionCommandService.refundCoffeeChat(coffeechatId, userId, totalQuantity);
+            int totalPrice = mentorDTO.getPrice() * coffeechat.getPurchaseQuantity();
+            transactionCommandService.refundCoffeeChat(coffeechatId, userId, totalPrice);
         }
+        Long mentorUserId = mentorClient.getUserIdByMentorId(coffeechat.getMentorId()).getData();
 
-        // 5. 커피챗 객체 업데이트하기
-        coffeechat.cancelCoffeechat(coffeechatCancelRequest.getCancelReasonId());
 
-        // 6. 채팅방 취소
+        cancelCoffeechatTransactional(coffeechatCancelRequest, coffeechat, mentorUserId);
+    }
+
+    @Transactional
+    protected void cancelCoffeechatTransactional(CoffeechatCancelRequest request,
+                                                 Coffeechat coffeechat, Long mentorUserId) {
+        // 1. 커피챗 상태 업데이트
+        coffeechat.cancelCoffeechat(request.getCancelReasonId());
+
+        // 2. 채팅방 취소 처리
         String roomId = roomService.findRoomIdByCoffeeChatId(coffeechat.getCoffeechatId());
         roomService.cancelRoom(roomId);
 
-        // 7. 멘토에게 커피챗 취소 알림
+        // 3. 멘토에게 커피챗 취소 알림 전송
         notificationCommandService.sendNotification(
                 new NotificationSendRequest(
-                        mentorClient.getUserIdByMentorId(coffeechat.getMentorId()).getData()
-                        , 6L
-                        , coffeechat.getCoffeechatId()
-                        , "진행 예정인 커피챗이 취소되었습니다."
+                        mentorUserId,
+                        6L, // 알림 타입 ID
+                        coffeechat.getCoffeechatId(),
+                        "진행 예정인 커피챗이 취소되었습니다."
                 )
         );
     }
+
 }

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/coffeechat/command/application/service/CoffeechatInternalService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/coffeechat/command/application/service/CoffeechatInternalService.java
@@ -1,0 +1,39 @@
+package com.newbit.newbitfeatureservice.coffeechat.command.application.service;
+
+import com.newbit.newbitfeatureservice.coffeechat.command.application.dto.request.CoffeechatCancelRequest;
+import com.newbit.newbitfeatureservice.coffeechat.command.domain.aggregate.Coffeechat;
+import com.newbit.newbitfeatureservice.coffeeletter.service.RoomService;
+import com.newbit.newbitfeatureservice.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.newbitfeatureservice.notification.command.application.service.NotificationCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeechatInternalService {
+
+    private final RoomService roomService;
+    private final NotificationCommandService notificationCommandService;
+
+    @Transactional
+    protected void cancelCoffeechatTransactional(CoffeechatCancelRequest request,
+                                                 Coffeechat coffeechat, Long mentorUserId) {
+        // 1. 커피챗 상태 업데이트
+        coffeechat.cancelCoffeechat(request.getCancelReasonId());
+
+        // 2. 채팅방 취소 처리
+        String roomId = roomService.findRoomIdByCoffeeChatId(coffeechat.getCoffeechatId());
+        roomService.cancelRoom(roomId);
+
+        // 3. 멘토에게 커피챗 취소 알림 전송
+        notificationCommandService.sendNotification(
+                new NotificationSendRequest(
+                        mentorUserId,
+                        6L, // 알림 타입 ID
+                        coffeechat.getCoffeechatId(),
+                        "진행 예정인 커피챗이 취소되었습니다."
+                )
+        );
+    }
+}

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/coffeechat/command/application/service/CoffeechatInternalServiceTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/coffeechat/command/application/service/CoffeechatInternalServiceTest.java
@@ -1,0 +1,62 @@
+package com.newbit.newbitfeatureservice.coffeechat.command.application.service;
+
+import com.newbit.newbitfeatureservice.coffeechat.command.application.dto.request.CoffeechatCancelRequest;
+import com.newbit.newbitfeatureservice.coffeechat.command.domain.aggregate.Coffeechat;
+import com.newbit.newbitfeatureservice.coffeechat.query.dto.response.ProgressStatus;
+import com.newbit.newbitfeatureservice.coffeeletter.service.RoomService;
+import com.newbit.newbitfeatureservice.notification.command.application.dto.request.NotificationSendRequest;
+import com.newbit.newbitfeatureservice.notification.command.application.service.NotificationCommandService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CoffeechatInternalServiceTest {
+
+    @InjectMocks
+    private CoffeechatInternalService internalService;
+
+    @Mock
+    private RoomService roomService;
+
+    @Mock
+    private NotificationCommandService notificationCommandService;
+
+    @Test
+    @DisplayName("cancelCoffeechatTransactional 성공 시 상태 업데이트, 방 취소, 알림 전송")
+    void cancelCoffeechatTransactional_success() {
+        // given
+        Long mentorUserId = 10L;
+        Long coffeechatId  = 20L;
+        Long cancelReasonId = 1L;
+
+        CoffeechatCancelRequest request = new CoffeechatCancelRequest(cancelReasonId);
+        Coffeechat coffeechat = Coffeechat.of(5L, 6L, "테스트 메시지", 2);
+        ReflectionTestUtils.setField(coffeechat, "coffeechatId", coffeechatId);
+
+        when(roomService.findRoomIdByCoffeeChatId(coffeechatId))
+                .thenReturn("room-123");
+
+        // when
+        internalService.cancelCoffeechatTransactional(request, coffeechat, mentorUserId);
+
+        // then: 상태가 CANCEL로 변경
+        assertEquals(ProgressStatus.CANCEL, coffeechat.getProgressStatus());
+
+        // 채팅방 취소 호출 검증
+        verify(roomService).findRoomIdByCoffeeChatId(coffeechatId);
+        verify(roomService).cancelRoom("room-123");
+
+        // 알림 전송 호출 검증
+        verify(notificationCommandService).sendNotification(
+                any(NotificationSendRequest.class)
+        );
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
- 커피챗 취소 db처리 로직과 외부 서비스 호출로직 분리(close #464)

### 🪐 작업 내용
- 커피챗 취소 기능에서 Transactional로 처리할 로직 분리
- 테스트 코드 수정 및 작성

### ✅ Check List (선택)
- [x] api 테스트 
- [x] 단위 테스트 코드 작성
