### PR TITLE
[BE] NBT-316 게시글 작성 transactional 분리

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostInternalService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostInternalService.java
@@ -3,8 +3,10 @@ package com.newbit.newbitfeatureservice.post.service;
 import com.newbit.newbitfeatureservice.common.exception.BusinessException;
 import com.newbit.newbitfeatureservice.common.exception.ErrorCode;
 import com.newbit.newbitfeatureservice.post.dto.request.PostCreateRequest;
+import com.newbit.newbitfeatureservice.post.entity.Attachment;
 import com.newbit.newbitfeatureservice.post.entity.Post;
 import com.newbit.newbitfeatureservice.post.entity.PostCategory;
+import com.newbit.newbitfeatureservice.post.repository.AttachmentRepository;
 import com.newbit.newbitfeatureservice.post.repository.PostCategoryRepository;
 import com.newbit.newbitfeatureservice.post.repository.PostRepository;
 import com.newbit.newbitfeatureservice.security.model.CustomUser;
@@ -17,7 +19,8 @@ import org.springframework.stereotype.Service;
 public class PostInternalService {
 
     private final PostRepository postRepository;
-    private final PostCategoryRepository postCategoryRepository;  // ✅ 추가
+    private final PostCategoryRepository postCategoryRepository;
+    private final AttachmentRepository attachmentRepository;
 
     @Transactional
     public Post createPostInternal(PostCreateRequest request, CustomUser user) {
@@ -30,11 +33,21 @@ public class PostInternalService {
                 .content(request.getContent())
                 .userId(user.getUserId())
                 .postCategoryId(postCategory.getId())
-                .postCategory(postCategory)  // ✅ 여기 추가
+                .postCategory(postCategory)
                 .likeCount(0)
                 .reportCount(0)
                 .isNotice(false)
                 .build();
+
+        if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
+            for (String imageUrl : request.getImageUrls()) {
+                Attachment attachment = Attachment.builder()
+                        .post(post)
+                        .imageUrl(imageUrl)
+                        .build();
+                attachmentRepository.save(attachment);
+            }
+        }
 
         return postRepository.save(post);
     }

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostService.java
@@ -38,7 +38,6 @@ public class PostService {
     private final PostInternalService postInternalService;
     private final AttachmentRepository attachmentRepository;
 
-    @Transactional
     public PostResponse createPost(PostCreateRequest request, CustomUser user) {
         if (user == null) {
             throw new BusinessException(ErrorCode.ONLY_USER_CAN_CREATE_POST);
@@ -50,20 +49,11 @@ public class PostService {
             throw new BusinessException(ErrorCode.POST_CREATION_FAILED);
         }
 
-//        pointTransactionCommandService.givePointByType(user.getUserId(), PointTypeConstants.POSTS, post.getId());
+        pointTransactionCommandService.givePointByType(user.getUserId(), PointTypeConstants.POSTS, post.getId());
 
         ApiResponse<UserDTO> response = userFeignClient.getUserByUserId(user.getUserId());
         String writerName = response.getData() != null ? response.getData().getNickname() : null;
 
-        if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
-            for (String imageUrl : request.getImageUrls()) {
-                Attachment attachment = Attachment.builder()
-                        .post(post)
-                        .imageUrl(imageUrl)
-                        .build();
-                attachmentRepository.save(attachment);
-            }
-        }
 
         String categoryName = post.getPostCategory().getName();
 

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/post/service/PostServiceTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/post/service/PostServiceTest.java
@@ -16,6 +16,7 @@ import com.newbit.newbitfeatureservice.post.repository.AttachmentRepository;
 import com.newbit.newbitfeatureservice.post.repository.CommentRepository;
 import com.newbit.newbitfeatureservice.post.repository.PostRepository;
 import com.newbit.newbitfeatureservice.purchase.command.application.service.PointTransactionCommandService;
+import com.newbit.newbitfeatureservice.purchase.command.domain.PointTypeConstants;
 import com.newbit.newbitfeatureservice.security.model.CustomUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -124,13 +125,15 @@ class PostServiceTest {
         assertThat(response.getTitle()).isEqualTo("이미지 포함 글");
         assertThat(response.getContent()).isEqualTo("이미지가 있는 게시글입니다.");
         assertThat(response.getPostCategoryId()).isEqualTo(1L);
+        assertThat(response.getCategoryName()).isEqualTo("자유게시판"); // ✅ category name 추가 확인
         assertThat(response.isNotice()).isFalse();
         assertThat(response.getWriterName()).isEqualTo("작성자닉네임");
         assertThat(response.getImageUrls()).containsExactly("https://example-bucket.s3.ap-northeast-2.amazonaws.com/posts/test-image.jpg");
 
-        verify(attachmentRepository, times(1)).save(any(Attachment.class));
-    }
+        verify(pointTransactionCommandService, times(1)).givePointByType(user.getUserId(), PointTypeConstants.POSTS, 123L);
 
+        verify(attachmentRepository, times(1)).findByPostId(123L);
+    }
 
 
     @Test


### PR DESCRIPTION
### 🛰️ Issue
- 게시글 작성 transactional 분리 (close #544)

### 🪐 작업 내용
- 게시글 등록 로직에서 Transactional이 필요한 DB 처리 로직 분리
- 테스트 코드 수정

### ✅ Check List (선택)
- [x] Postman api 테스트  
- [x] 단위 테스트 코드 성공
