### PR TITLE
Nbt 389 fe 라우터 수정 및 칼럼 등록 버튼 클릭 시 경로 설정

### DIFF
--- a/newbit-frontend/src/features/column/router.js
+++ b/newbit-frontend/src/features/column/router.js
@@ -5,12 +5,6 @@ export const columnRoutes = [
         component: () => import("@/features/column/views/ColumnListView.vue"),
     },
     {
-        path: "/columns/:id",
-        name: "ColumnDetail",
-        component: () => import("@/features/column/views/ColumnDetailView.vue"),
-        props: true
-    },
-    {
         path: "/columns/requests",
         name: "ColumnRequestPage",
         component: () => import("@/features/column/views/ColumnRequestView.vue")
@@ -20,5 +14,11 @@ export const columnRoutes = [
         name: "ColumnEditRequestPage",
         component: () => import("@/features/column/views/ColumnEditRequestView.vue"),
         props: true,
+    },
+    {
+        path: "/columns/:id",
+        name: "ColumnDetail",
+        component: () => import("@/features/column/views/ColumnDetailView.vue"),
+        props: true
     },
 ];

--- a/newbit-frontend/src/features/column/views/ColumnListView.vue
+++ b/newbit-frontend/src/features/column/views/ColumnListView.vue
@@ -50,7 +50,7 @@ const handleSearch = () => {
 
 const onClickCreate = () => {
 
-  console.log('칼럼 등록 버튼 클릭됨')
+  router.push('/columns/requests')
 
 }
 </script>


### PR DESCRIPTION
### 🛰️ Issue
Nbt 389 fe 라우터 수정 및 칼럼 등록 버튼 클릭 시 경로 설정	

### 🪐 작업 내용
- 문제점
/columns/:id → :id = 'requests' 로 인식됨
"requests"를 :id로 오인해서 ColumnDetailView가 렌더링됨

- 해결책
정적인 경로가 동적 경로보다 먼저 선언되어야 올바르게 동작하기 때문에 라우터에서 경로 순서 변경

