### PR TITLE
feat: NBT-396 좋아요 구독 콘텐츠 api 반환 params 수정, seriesService에 칼럼 개수 반환하는 …

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/service/SeriesService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/service/SeriesService.java
@@ -211,5 +211,10 @@ public class SeriesService {
         Page<Series> seriesPage = seriesRepository.searchSeriesByKeyword(condition.getKeyword(), pageable);
         return seriesPage.map(seriesMapper::toMySeriesListDto);
     }
+
+    @Transactional(readOnly = true)
+    public int getColumnCountBySeriesId(Long seriesId) {
+        return columnRepository.findAllBySeries_SeriesId(seriesId).size();
+    }
 }
 

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/like/dto/response/LikedColumnResponse.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/like/dto/response/LikedColumnResponse.java
@@ -24,6 +24,15 @@ public class LikedColumnResponse {
     @Schema(description = "작성자 ID", example = "15")
     private Long authorId;
 
+    @Schema(description = "작성자 닉네임", example = "개발자도토리")
+    private String authorNickname;
+
+    @Schema(description = "칼럼 썸네일 URL", example = "https://example.com/image.jpg")
+    private String thumbnailUrl;
+
+    @Schema(description = "칼럼 가격", example = "1000")
+    private Integer price;
+
     @Schema(description = "좋아요 생성 시간", example = "2023-08-15T14:30:15")
     private LocalDateTime likedAt;
 } 

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/like/dto/response/LikedPostResponse.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/like/dto/response/LikedPostResponse.java
@@ -24,6 +24,12 @@ public class LikedPostResponse {
     @Schema(description = "작성자 ID", example = "15")
     private Long authorId;
     
+    @Schema(description = "작성자 닉네임", example = "홍길동")
+    private String authorNickname;
+    
     @Schema(description = "좋아요 생성 시간", example = "2023-08-15T14:30:15")
     private LocalDateTime likedAt;
+    
+    @Schema(description = "게시글 좋아요 수", example = "12")
+    private Integer likeCount;
 } 

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/post/service/PostService.java
@@ -365,4 +365,10 @@ public class PostService {
         return post.getTitle();
     }
 
+    @Transactional(readOnly = true)
+    public int getPostLikeCount(Long postId) {
+        Post post = getPost(postId);
+        return post.getLikeCount();
+    }
+
 }

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/subscription/dto/response/SubscriptionResponse.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/subscription/dto/response/SubscriptionResponse.java
@@ -30,6 +30,18 @@ public class SubscriptionResponse {
     @Schema(description = "상태 변경 시간", example = "2023-08-15T14:30:15")
     private LocalDateTime updatedAt;
     
+    @Schema(description = "시리즈 썸네일 URL", example = "https://example.com/series.jpg")
+    private String thumbnailUrl;
+
+    @Schema(description = "시리즈 제목", example = "개발자 성장 시리즈")
+    private String seriesTitle;
+
+    @Schema(description = "발행자 닉네임", example = "멘토홍길동")
+    private String mentorNickname;
+
+    @Schema(description = "시리즈에 발행된 칼럼 개수", example = "5")
+    private Integer columnCount;
+    
     public static SubscriptionResponse from(Subscription subscription) {
         return SubscriptionResponse.builder()
                 .seriesId(subscription.getSeriesId())

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/subscription/service/SubscriptionService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/subscription/service/SubscriptionService.java
@@ -3,6 +3,7 @@ package com.newbit.newbitfeatureservice.subscription.service;
 import java.util.List;
 import java.util.Optional;
 
+import com.newbit.newbitfeatureservice.column.domain.Series;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,7 +65,21 @@ public class SubscriptionService {
     @Transactional(readOnly = true)
     public List<SubscriptionResponse> getUserSubscriptions(Long userId) {
         return subscriptionRepository.findByUserId(userId).stream()
-                .map(SubscriptionResponse::from)
+                .map(subscription -> {
+                    Series series = seriesService.getSeries(subscription.getSeriesId());
+                    int columnCount = seriesService.getColumnCountBySeriesId(series.getSeriesId());
+                    return SubscriptionResponse.builder()
+                            .seriesId(subscription.getSeriesId())
+                            .userId(subscription.getUserId())
+                            .subscribed(true)
+                            .createdAt(subscription.getCreatedAt())
+                            .updatedAt(subscription.getUpdatedAt())
+                            .thumbnailUrl(series.getThumbnailUrl())
+                            .seriesTitle(series.getTitle())
+                            .mentorNickname(series.getMentorNickname())
+                            .columnCount(columnCount)
+                            .build();
+                })
                 .toList();
     }
     

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/payment/command/application/service/PaymentCommandServiceTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/payment/command/application/service/PaymentCommandServiceTest.java
@@ -90,9 +90,7 @@ class PaymentCommandServiceTest {
     @Test
     @DisplayName("결제 상세 조회 - 성공")
     void getPayment_success() {
-        payment.updatePaymentKey("test-payment-key");
-        payment.approve(LocalDateTime.now());
-        payment.updateReceiptUrl("https://receipt.url");
+        payment.approve("test-payment-key", LocalDateTime.now(), "https://receipt.url");
         setPaymentId(payment, 1L);
         when(paymentRepository.findById(anyLong())).thenReturn(Optional.of(payment));
         var response = paymentCommandService.getPayment(1L);
@@ -107,8 +105,7 @@ class PaymentCommandServiceTest {
     @Test
     @DisplayName("주문 ID로 결제 상세 조회 - 성공")
     void getPaymentByOrderId_success() {
-        payment.updatePaymentKey("test-payment-key");
-        payment.approve(LocalDateTime.now());
+        payment.approve("test-payment-key", LocalDateTime.now(), null);
         setPaymentId(payment, 1L);
         when(paymentRepository.findByOrderId(anyString())).thenReturn(Optional.of(payment));
         var response = paymentCommandService.getPaymentByOrderId("test-order-id");

--- a/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/subscription/service/SubscriptionServiceTest.java
+++ b/newbit-feature-service/src/test/java/com/newbit/newbitfeatureservice/subscription/service/SubscriptionServiceTest.java
@@ -169,10 +169,21 @@ class SubscriptionServiceTest {
         
         Subscription sub1 = createSubscription(userId, seriesId1);
         Subscription sub2 = createSubscription(userId, seriesId2);
+        // SeriesService에서 seriesId로 Series mock 반환
+        Series mockSeries1 = mock(Series.class);
+        when(mockSeries1.getSeriesId()).thenReturn(seriesId1);
+        when(mockSeries1.getThumbnailUrl()).thenReturn("https://example.com/series1.jpg");
+        when(mockSeries1.getTitle()).thenReturn("시리즈1");
+        when(mockSeries1.getMentorNickname()).thenReturn("멘토홍길동");
+        Series mockSeries2 = mock(Series.class);
+        when(mockSeries2.getSeriesId()).thenReturn(seriesId2);
+        when(mockSeries2.getThumbnailUrl()).thenReturn("https://example.com/series2.jpg");
+        when(mockSeries2.getTitle()).thenReturn("시리즈2");
+        when(mockSeries2.getMentorNickname()).thenReturn("멘토이몽룡");
+        when(seriesService.getSeries(seriesId1)).thenReturn(mockSeries1);
+        when(seriesService.getSeries(seriesId2)).thenReturn(mockSeries2);
         
-        List<Subscription> subscriptions = Arrays.asList(sub1, sub2);
-        
-        when(subscriptionRepository.findByUserId(userId)).thenReturn(subscriptions);
+        when(subscriptionRepository.findByUserId(userId)).thenReturn(Arrays.asList(sub1, sub2));
         
         // When
         List<SubscriptionResponse> responses = subscriptionService.getUserSubscriptions(userId);


### PR DESCRIPTION
…서비스 추가, postService에 좋아요 카운트 반환 서비스 추가, payment 테스트 mock 에러 수정

### 🛰️ Issue
Close #683

### 🪐 작업 내용
- 좋아요 구독 api 반환 params 수정
- 좋아요 칼럼 api 반환 params 수정
- 구독한 시리즈 api 반환 prams 수정
- seriesService에 칼럼 개수 반환하는 서비스 추가
- postService에 좋아요 카운트 반환 서비스 추가
- (기타) payment 테스트 mock 에러 수정(테스트 코드 돌리다가 발견해서 수정)

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] 단위 테스트
