### PR TITLE
Nbt 418 fe 칼럼 목록 조회 api 연동

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/ColumnImageController.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/ColumnImageController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1/columns")
+@RequestMapping("/columns")
 @RequiredArgsConstructor
 @Tag(name = "칼럼 이미지 API", description = "칼럼 이미지 업로드 관련 API ")
 public class ColumnImageController {

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/SeriesImageController.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/SeriesImageController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1/series/images")
+@RequestMapping("/series")
 @RequiredArgsConstructor
 @Tag(name = "시리즈 이미지 API", description = "시리즈 이미지 업로드 관련 API")
 public class SeriesImageController {

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/domain/Column.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/domain/Column.java
@@ -56,9 +56,6 @@ public class Column {
     @jakarta.persistence.Column(name = "mentor_id")
     private Long mentorId;
 
-    @jakarta.persistence.Column(nullable = false)
-    private String mentorNickname;
-
     @ManyToOne
     @JoinColumn(name = "series_id")
     private Series series;

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnListResponseDto.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnListResponseDto.java
@@ -31,13 +31,14 @@ public class GetColumnListResponseDto {
 
     public GetColumnListResponseDto(Long columnId, String title, String thumbnailUrl,
                                     Integer price, Integer likeCount,
-                                    Long mentorId) {
+                                    Long mentorId, String mentorNickname) {
         this.columnId = columnId;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
         this.price = price;
         this.likeCount = likeCount;
         this.mentorId = mentorId;
+        this.mentorNickname = mentorNickname;
     }
     public void setMentorNickname(String nickname) {
         this.mentorNickname = nickname;

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnListResponseDto.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnListResponseDto.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Schema(description = "공개 칼럼 리스트 조회 응답")
 public class GetColumnListResponseDto {
@@ -29,15 +31,19 @@ public class GetColumnListResponseDto {
     @Schema(description = "멘토 닉네임", example = "개발자도토리")
     private String mentorNickname;
 
+    @Schema(description = "작성 일시", example = "2025-07-02T09:00:00")
+    private LocalDateTime createdAt;
+
     public GetColumnListResponseDto(Long columnId, String title, String thumbnailUrl,
                                     Integer price, Integer likeCount,
-                                    Long mentorId) {
+                                    Long mentorId, LocalDateTime createdAt) {
         this.columnId = columnId;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
         this.price = price;
         this.likeCount = likeCount;
         this.mentorId = mentorId;
+        this.createdAt = createdAt;
     }
     public void setMentorNickname(String nickname) {
         this.mentorNickname = nickname;

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnListResponseDto.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnListResponseDto.java
@@ -31,14 +31,13 @@ public class GetColumnListResponseDto {
 
     public GetColumnListResponseDto(Long columnId, String title, String thumbnailUrl,
                                     Integer price, Integer likeCount,
-                                    Long mentorId, String mentorNickname) {
+                                    Long mentorId) {
         this.columnId = columnId;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
         this.price = price;
         this.likeCount = likeCount;
         this.mentorId = mentorId;
-        this.mentorNickname = mentorNickname;
     }
     public void setMentorNickname(String nickname) {
         this.mentorNickname = nickname;

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRepository.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRepository.java
@@ -17,7 +17,7 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
     // 공개 칼럼 리스트 조회 (페이징)
     @Query("""
         SELECT new com.newbit.newbitfeatureservice.column.dto.response.GetColumnListResponseDto(
-            c.columnId, c.title, c.thumbnailUrl, c.price, c.likeCount, c.mentorId
+            c.columnId, c.title, c.thumbnailUrl, c.price, c.likeCount, c.mentorId, c.createdAt
         )
         FROM Column c
         WHERE c.isPublic = true
@@ -45,7 +45,7 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
     // 작성자, 제목으로 검색
     @Query("""
     SELECT new com.newbit.newbitfeatureservice.column.dto.response.GetColumnListResponseDto(
-        c.columnId, c.title, c.thumbnailUrl, c.price, c.likeCount, c.mentorId
+        c.columnId, c.title, c.thumbnailUrl, c.price, c.likeCount, c.mentorId, c.createdAt
     )
     FROM Column c
     WHERE c.isPublic = true

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRepository.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRepository.java
@@ -51,11 +51,10 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
     WHERE c.isPublic = true
     AND (
         :keyword IS NULL OR
-        LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-        LOWER(c.mentorNickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
     )
     ORDER BY c.createdAt DESC
 """)
-    Page<GetColumnListResponseDto> searchPublicColumns(@Param("keyword") String keyword, Pageable pageable);
+    Page<GetColumnListResponseDto> searchPublicColumnsByTitle(@Param("keyword") String keyword, Pageable pageable);
 
 }

--- a/newbit-frontend/src/api/column.js
+++ b/newbit-frontend/src/api/column.js
@@ -4,64 +4,64 @@ import api from './axios'
 
 // 공개된 칼럼 목록 조회 (페이징)
 export const getPublicColumnList = (page = 0, size = 10) =>
-    api.get('/columns/public-list', { params: { page, size } })
+    api.get('feature/columns/public-list', { params: { page, size } })
 
 // 공개 칼럼 검색
 export const searchPublicColumns = (condition, page = 0, size = 10) =>
-    api.get('/columns/public-list/search', {
+    api.get('feature/columns/public-list/search', {
         params: { ...condition, page, size },
     })
 
 // 칼럼 상세 조회 (구매자용)
 export const getColumnDetail = (columnId, userId) =>
-    api.get(`/columns/${columnId}/user/${userId}`)
+    api.get(`feature/columns/${columnId}/user/${userId}`)
 
 // 멘토 본인 칼럼 목록 조회
 export const getMyColumnList = (page = 0, size = 10) =>
-    api.get('/columns/my', { params: { page, size } })
+    api.get('feature/columns/my', { params: { page, size } })
 
 
 /* --- 칼럼 요청 관련 --- */
 
 // 칼럼 등록 요청
 export const createColumnRequest = (data) =>
-    api.post('/columns/requests', data)
+    api.post('feature/columns/requests', data)
 
 // 칼럼 수정 요청
 export const updateColumnRequest = (columnId, data) =>
-    api.post(`/columns/requests/${columnId}/edit`, data)
+    api.post(`feature/columns/requests/${columnId}/edit`, data)
 
 // 칼럼 삭제 요청
 export const deleteColumnRequest = (columnId, data) =>
-    api.post(`/columns/requests/${columnId}/delete`, data)
+    api.post(`feature/columns/requests/${columnId}/delete`, data)
 
 // 본인 칼럼 요청 목록 조회
 export const getMyColumnRequests = () =>
-    api.get('/columns/requests/my')
+    api.get('feature/columns/requests/my')
 
 
 /* --- 칼럼 관리자 승인/거절 --- */
 
 // 등록 요청 승인/거절
 export const approveCreateColumn = (data) =>
-    api.post('/columns/requests/approve/create', data)
+    api.post('feature/columns/requests/approve/create', data)
 
 export const rejectCreateColumn = (data) =>
-    api.post('/columns/requests/reject/create', data)
+    api.post('feature/columns/requests/reject/create', data)
 
 // 수정 요청 승인/거절
 export const approveUpdateColumn = (data) =>
-    api.post('/columns/requests/approve/update', data)
+    api.post('feature/columns/requests/approve/update', data)
 
 export const rejectUpdateColumn = (data) =>
-    api.post('/columns/requests/reject/update', data)
+    api.post('feature/columns/requests/reject/update', data)
 
 // 삭제 요청 승인/거절
 export const approveDeleteColumn = (data) =>
-    api.post('/columns/requests/approve/delete', data)
+    api.post('feature/columns/requests/approve/delete', data)
 
 export const rejectDeleteColumn = (data) =>
-    api.post('/columns/requests/reject/delete', data)
+    api.post('feature/columns/requests/reject/delete', data)
 
 
 /* --- 칼럼 이미지 업로드 --- */
@@ -70,7 +70,7 @@ export const rejectDeleteColumn = (data) =>
 export const uploadColumnThumbnail = (file) => {
     const formData = new FormData()
     formData.append('file', file)
-    return api.post('/columns/thumbnails', formData, {
+    return api.post('feature/columns/thumbnails', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
     })
 }
@@ -79,7 +79,7 @@ export const uploadColumnThumbnail = (file) => {
 export const uploadColumnContentImage = (file) => {
     const formData = new FormData()
     formData.append('file', file)
-    return api.post('/columns/content-images', formData, {
+    return api.post('feature/columns/content-images', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
     })
 }
@@ -88,35 +88,35 @@ export const uploadColumnContentImage = (file) => {
 
 // 시리즈 생성
 export const createSeries = (data) =>
-    api.post('/series', data)
+    api.post('feature/series', data)
 
 // 시리즈 수정
 export const updateSeries = (seriesId, data) =>
-    api.patch(`/series/${seriesId}`, data)
+    api.patch(`feature/series/${seriesId}`, data)
 
 // 시리즈 삭제
 export const deleteSeries = (seriesId) =>
-    api.delete(`/series/${seriesId}`)
+    api.delete(`feature/series/${seriesId}`)
 
 // 시리즈 상세 조회
 export const getSeriesDetail = (seriesId) =>
-    api.get(`/series/${seriesId}`)
+    api.get(`feature/series/${seriesId}`)
 
 // 본인 시리즈 목록 조회 (멘토)
 export const getMySeriesList = (page = 0, size = 10) =>
-    api.get('/series/my', { params: { page, size } })
+    api.get('feature/series/my', { params: { page, size } })
 
 // 시리즈에 포함된 칼럼 목록 조회
 export const getSeriesColumns = (seriesId, page = 0, size = 10) =>
-    api.get(`/series/${seriesId}/columns`, { params: { page, size } })
+    api.get(`feature/series/${seriesId}/columns`, { params: { page, size } })
 
 // 공개된 시리즈 목록 조회
 export const getPublicSeriesList = (page = 0, size = 10) =>
-    api.get('/series', { params: { page, size } })
+    api.get('feature/series', { params: { page, size } })
 
 // 공개된 시리즈 검색
 export const searchPublicSeriesList = (condition, page = 0, size = 10) =>
-    api.get('/series/public-list/search', {
+    api.get('feature/series/public-list/search', {
         params: { ...condition, page, size },
     })
 
@@ -127,7 +127,7 @@ export const searchPublicSeriesList = (condition, page = 0, size = 10) =>
 export const uploadSeriesThumbnail = (file) => {
     const formData = new FormData()
     formData.append('file', file)
-    return api.post('/series/thumbnail', formData, {
+    return api.post('feature/series/thumbnail', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
     })
 }

--- a/newbit-frontend/src/api/column.js
+++ b/newbit-frontend/src/api/column.js
@@ -1,0 +1,133 @@
+import api from './axios'
+
+/* --- 칼럼 관련 --- */
+
+// 공개된 칼럼 목록 조회 (페이징)
+export const getPublicColumnList = (page = 0, size = 10) =>
+    api.get('/columns/public-list', { params: { page, size } })
+
+// 공개 칼럼 검색
+export const searchPublicColumns = (condition, page = 0, size = 10) =>
+    api.get('/columns/public-list/search', {
+        params: { ...condition, page, size },
+    })
+
+// 칼럼 상세 조회 (구매자용)
+export const getColumnDetail = (columnId, userId) =>
+    api.get(`/columns/${columnId}/user/${userId}`)
+
+// 멘토 본인 칼럼 목록 조회
+export const getMyColumnList = (page = 0, size = 10) =>
+    api.get('/columns/my', { params: { page, size } })
+
+
+/* --- 칼럼 요청 관련 --- */
+
+// 칼럼 등록 요청
+export const createColumnRequest = (data) =>
+    api.post('/columns/requests', data)
+
+// 칼럼 수정 요청
+export const updateColumnRequest = (columnId, data) =>
+    api.post(`/columns/requests/${columnId}/edit`, data)
+
+// 칼럼 삭제 요청
+export const deleteColumnRequest = (columnId, data) =>
+    api.post(`/columns/requests/${columnId}/delete`, data)
+
+// 본인 칼럼 요청 목록 조회
+export const getMyColumnRequests = () =>
+    api.get('/columns/requests/my')
+
+
+/* --- 칼럼 관리자 승인/거절 --- */
+
+// 등록 요청 승인/거절
+export const approveCreateColumn = (data) =>
+    api.post('/columns/requests/approve/create', data)
+
+export const rejectCreateColumn = (data) =>
+    api.post('/columns/requests/reject/create', data)
+
+// 수정 요청 승인/거절
+export const approveUpdateColumn = (data) =>
+    api.post('/columns/requests/approve/update', data)
+
+export const rejectUpdateColumn = (data) =>
+    api.post('/columns/requests/reject/update', data)
+
+// 삭제 요청 승인/거절
+export const approveDeleteColumn = (data) =>
+    api.post('/columns/requests/approve/delete', data)
+
+export const rejectDeleteColumn = (data) =>
+    api.post('/columns/requests/reject/delete', data)
+
+
+/* --- 칼럼 이미지 업로드 --- */
+
+// 썸네일 업로드
+export const uploadColumnThumbnail = (file) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    return api.post('/columns/thumbnails', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+    })
+}
+
+// 본문 이미지 업로드
+export const uploadColumnContentImage = (file) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    return api.post('/columns/content-images', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+    })
+}
+
+/* --- 시리즈 관련 --- */
+
+// 시리즈 생성
+export const createSeries = (data) =>
+    api.post('/series', data)
+
+// 시리즈 수정
+export const updateSeries = (seriesId, data) =>
+    api.patch(`/series/${seriesId}`, data)
+
+// 시리즈 삭제
+export const deleteSeries = (seriesId) =>
+    api.delete(`/series/${seriesId}`)
+
+// 시리즈 상세 조회
+export const getSeriesDetail = (seriesId) =>
+    api.get(`/series/${seriesId}`)
+
+// 본인 시리즈 목록 조회 (멘토)
+export const getMySeriesList = (page = 0, size = 10) =>
+    api.get('/series/my', { params: { page, size } })
+
+// 시리즈에 포함된 칼럼 목록 조회
+export const getSeriesColumns = (seriesId, page = 0, size = 10) =>
+    api.get(`/series/${seriesId}/columns`, { params: { page, size } })
+
+// 공개된 시리즈 목록 조회
+export const getPublicSeriesList = (page = 0, size = 10) =>
+    api.get('/series', { params: { page, size } })
+
+// 공개된 시리즈 검색
+export const searchPublicSeriesList = (condition, page = 0, size = 10) =>
+    api.get('/series/public-list/search', {
+        params: { ...condition, page, size },
+    })
+
+
+/* --- 시리즈 이미지 업로드 --- */
+
+// 시리즈 썸네일 업로드
+export const uploadSeriesThumbnail = (file) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    return api.post('/series/thumbnail', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+    })
+}

--- a/newbit-frontend/src/features/column/components/ColumnCard.vue
+++ b/newbit-frontend/src/features/column/components/ColumnCard.vue
@@ -34,7 +34,9 @@ const formattedDate = computed(() => {
     <!-- 텍스트 -->
     <div class="flex flex-col justify-between flex-1 pr-4">
       <!-- 제목 -->
-      <h2 class="text-heading3 mb-4">{{ column.title }}</h2>
+      <div class="mb-20">
+        <h2 class="text-heading3">{{ column.title }}</h2>
+      </div>
 
       <!-- 다이아 가격 -->
       <div v-if="column.diamondCount !== undefined" class="flex items-center gap-1 text-13px-regular text-[var(--newbitdark)] mb-4">

--- a/newbit-frontend/src/features/column/components/ColumnCard.vue
+++ b/newbit-frontend/src/features/column/components/ColumnCard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {computed, ref} from 'vue'
+import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
 
 const props = defineProps({
@@ -9,24 +9,24 @@ const props = defineProps({
   }
 })
 
-const purchasedDate = computed(() => {
-  return props.column.purchasedAt
-      ? dayjs(props.column.purchasedAt).format('YYYY.MM.DD  HH:mm')
-      : ''
-})
-
-// 상태 관리
+// 좋아요 상태
 const isLiked = ref(false)
 const toggleLike = () => {
   isLiked.value = !isLiked.value
 }
 
-
-// 이미지 경로
+// 이미지
 const fallbackImg = new URL('@/assets/image/product-skeleton.png', import.meta.url).href
 const heartDefault = new URL('@/assets/image/heart-default.png', import.meta.url).href
 const heartActive = new URL('@/assets/image/heart-active.png', import.meta.url).href
 const diamondIcon = new URL('@/assets/image/diamond-icon.png', import.meta.url).href
+
+const formattedDate = computed(() => {
+  return props.column.createdAt
+      ? dayjs(new Date(props.column.createdAt)).format('YYYY.MM.DD')
+      : ''
+})
+
 </script>
 
 <template>
@@ -34,41 +34,35 @@ const diamondIcon = new URL('@/assets/image/diamond-icon.png', import.meta.url).
     <!-- 텍스트 -->
     <div class="flex flex-col justify-between flex-1 pr-4">
       <!-- 제목 -->
-      <h2 v-if="column.title" class="text-heading3 mb-20">
-        {{ column.title }}
-      </h2>
-      <h2 v-if="column.columnTitle" class="text-heading3 mb-20">
-        {{ column.columnTitle }}
-      </h2>
+      <h2 class="text-heading3 mb-4">{{ column.title }}</h2>
 
-      <!-- 다이아 -->
-      <div v-if="column.diamondCount" class="flex items-center gap-1 text-13px-regular text-[var(--newbitdark)] mb-4">
+      <!-- 다이아 가격 -->
+      <div v-if="column.diamondCount !== undefined" class="flex items-center gap-1 text-13px-regular text-[var(--newbitdark)] mb-4">
         <img :src="diamondIcon" alt="다이아" class="w-4 h-4" />
         <span>{{ column.diamondCount }}</span>
       </div>
 
       <!-- 좋아요 + 작성자 + 날짜 -->
       <div class="flex items-center gap-3 text-13px-regular text-[var(--newbitgray)]">
-        <!-- 하트 버튼 -->
-        <button v-if="column.likeCount" @click="toggleLike" class="w-5 h-4.5">
-          <img :src="isLiked ? heartActive : heartDefault" alt="좋아요 하트" class="w-full h-full" />
+        <!-- 하트 -->
+        <button v-if="column.likeCount !== undefined" @click="toggleLike" class="w-5 h-4.5">
+          <img :src="isLiked ? heartActive : heartDefault" alt="하트" class="w-full h-full" />
         </button>
 
-        <!-- 작성자 · 작성일 -->
-        <span v-if="column.mentorNickname">{{ column.mentorNickname }} | 작성일 {{ column.date }}</span>
-        <div class="flex flex-col gap-2">
-          <span v-if="column.purchasedAt">구매일시  {{ purchasedDate }}</span>
-          <span v-if="column.price">구매가격  {{ column.price }}</span>
-        </div>
+        <!-- 작성자와 작성일 -->
+        <span>
+          {{ column.mentorNickname }}
+          <template v-if="formattedDate"> | 작성 일시 {{ formattedDate }}</template>
+        </span>
       </div>
     </div>
 
-    <!-- 썸네일 -->
+    <!-- 썸네일 이미지 -->
     <div class="w-[300px] h-[180px]">
       <img
           :src="column.thumbnailUrl || fallbackImg"
           @error="(e) => (e.target.src = fallbackImg)"
-          alt="thumbnail"
+          alt="썸네일"
           class="w-full h-full object-cover rounded-lg"
       />
     </div>

--- a/newbit-frontend/src/features/column/components/ColumnCard.vue
+++ b/newbit-frontend/src/features/column/components/ColumnCard.vue
@@ -1,3 +1,4 @@
+<!-- ColumnCard.vue -->
 <script setup>
 import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
@@ -5,11 +6,11 @@ import dayjs from 'dayjs'
 const props = defineProps({
   column: {
     type: Object,
-    required: true
-  }
+    required: true,
+  },
 })
 
-// 좋아요 상태
+// 좋아요 상태 (임시 로컬 상태)
 const isLiked = ref(false)
 const toggleLike = () => {
   isLiked.value = !isLiked.value
@@ -21,12 +22,12 @@ const heartDefault = new URL('@/assets/image/heart-default.png', import.meta.url
 const heartActive = new URL('@/assets/image/heart-active.png', import.meta.url).href
 const diamondIcon = new URL('@/assets/image/diamond-icon.png', import.meta.url).href
 
+// 날짜 포맷
 const formattedDate = computed(() => {
   return props.column.createdAt
       ? dayjs(new Date(props.column.createdAt)).format('YYYY.MM.DD')
       : ''
 })
-
 </script>
 
 <template>

--- a/newbit-frontend/src/features/column/views/ColumnListView.vue
+++ b/newbit-frontend/src/features/column/views/ColumnListView.vue
@@ -17,17 +17,20 @@ const error = ref(null)
 
 const fetchColumns = async () => {
   try {
-    let res
-    const page = currentPage.value - 1 // 백엔드는 0부터 시작
+    const page = currentPage.value - 1
     const size = 5
+    let res, content = []
 
     if (searchKeyword.value.trim()) {
       res = await searchPublicColumns({ keyword: searchKeyword.value }, page, size)
+      content = res.data?.data?.content || []
+      totalPage.value = res.data?.data?.totalPages || 1
     } else {
       res = await getPublicColumnList(page, size)
+      content = res.data?.content || []
+      totalPage.value = res.data?.totalPages || 1
     }
 
-    const content = res.data.content || []
     columns.value = content.map(col => ({
       id: col.columnId,
       title: col.title,
@@ -35,15 +38,14 @@ const fetchColumns = async () => {
       mentorNickname: col.mentorNickname,
       diamondCount: col.price,
       likeCount: col.likeCount,
-      createdAt: col.createdAt // createdAt 필드가 없으면 기본값
+      createdAt: col.createdAt
     }))
-    totalPage.value = res.data.totalPages
     error.value = null
   } catch (e) {
-    console.error(e)
     error.value = '칼럼 목록을 불러오는 데 실패했습니다.'
   }
 }
+
 
 const handleSearch = () => {
   currentPage.value = 1


### PR DESCRIPTION
### 🛰️ Issue
Nbt 418 fe 칼럼 목록 조회 api 연동	

### 🪐 작업 내용
- 백엔드 createdAt 필드 추가
- mentorNickname 리포지토리 쿼리에서 삭제하고 서비스 로직에서 검색
- 포스트맨 결과 조회 성공 (에러 수정 완료)
- 검색기능, 칼럼 목록 조회 API 연동

