### PR TITLE
Nbt 426 fe 칼럼 상세 조회 api 연동

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnDetailResponseDto.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetColumnDetailResponseDto.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Schema(description = "공개 칼럼 상세 조회 응답")
 public class GetColumnDetailResponseDto {
@@ -32,8 +34,11 @@ public class GetColumnDetailResponseDto {
     @Schema(description = "멘토 닉네임", example = "개발자도토리")
     private String mentorNickname;
 
+    @Schema(description = "작성일")
+    private LocalDateTime createdAt;
+
     public GetColumnDetailResponseDto(Long columnId, String title, String content, Integer price,
-                                      String thumbnailUrl, int likeCount, Long mentorId) {
+                                      String thumbnailUrl, int likeCount, Long mentorId, LocalDateTime createdAt) {
         this.columnId = columnId;
         this.title = title;
         this.content = content;
@@ -41,6 +46,7 @@ public class GetColumnDetailResponseDto {
         this.thumbnailUrl = thumbnailUrl;
         this.likeCount = likeCount;
         this.mentorId = mentorId;
+        this.createdAt = createdAt;
     }
 
     public void setMentorNickname(String mentorNickname) {

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRepository.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRepository.java
@@ -25,9 +25,10 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
     """)
     Page<GetColumnListResponseDto> findAllByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 
+    // 칼럼 상세 조회
     @Query("""
     SELECT new com.newbit.newbitfeatureservice.column.dto.response.GetColumnDetailResponseDto(
-        c.columnId, c.title, c.content, c.price, c.thumbnailUrl, c.likeCount, c.mentorId
+        c.columnId, c.title, c.content, c.price, c.thumbnailUrl, c.likeCount, c.mentorId, c.createdAt
     )
     FROM Column c
     WHERE c.columnId = :columnId AND c.isPublic = true

--- a/newbit-frontend/src/features/column/components/ColumnCard.vue
+++ b/newbit-frontend/src/features/column/components/ColumnCard.vue
@@ -1,7 +1,9 @@
-<!-- ColumnCard.vue -->
 <script setup>
 import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
 
 const props = defineProps({
   column: {
@@ -9,6 +11,10 @@ const props = defineProps({
     required: true,
   },
 })
+
+const goToDetail = () => {
+  router.push(`/columns/${props.column.id}`)
+}
 
 // 좋아요 상태 (임시 로컬 상태)
 const isLiked = ref(false)
@@ -31,7 +37,9 @@ const formattedDate = computed(() => {
 </script>
 
 <template>
-  <div class="flex justify-between items-start p-5 border border-[var(--newbitdivider)] rounded-lg shadow-sm">
+  <div
+      class="flex justify-between items-start p-5 border border-[var(--newbitdivider)] rounded-lg shadow-sm"
+      @click="goToDetail">
     <!-- 텍스트 -->
     <div class="flex flex-col justify-between flex-1 pr-4">
       <!-- 제목 -->

--- a/newbit-frontend/src/features/column/views/ColumnDetailView.vue
+++ b/newbit-frontend/src/features/column/views/ColumnDetailView.vue
@@ -3,13 +3,16 @@ import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { getColumnDetail } from '@/api/column.js'
 import dayjs from 'dayjs'
+import { useAuthStore } from '@/features/stores/auth'
+
+const authStore = useAuthStore()
 
 const route = useRoute()
 const router = useRouter()
 
 const columnId = Number(route.params.id)
-const userId = 12 // TODO: 추후 auth 연동 시, store에서 동적으로 가져올 것
-
+const userId = authStore.userId || 12;
+// const userId = 12;
 const column = ref(null)
 const isMentor = true // TODO: 로그인 유저와 비교하여 판단
 
@@ -41,8 +44,8 @@ const formattedDate = computed(() => {
 
 onMounted(async () => {
   try {
-    const res = await getColumnDetail(userId, columnId)
-    column.value = res.data.data
+    const res = await getColumnDetail(columnId, userId)
+    column.value = res.data
   } catch (err) {
     console.error('칼럼 상세 조회 실패', err)
   }

--- a/newbit-frontend/src/features/column/views/ColumnDetailView.vue
+++ b/newbit-frontend/src/features/column/views/ColumnDetailView.vue
@@ -1,69 +1,57 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { getColumnDetail } from '@/api/column.js'
+import dayjs from 'dayjs'
 
 const route = useRoute()
 const router = useRouter()
-const columnId = route.params.id
 
-// TODO: 추후 로그인 사용자 정보에 따라 멘토 여부 판단
-const isMentor = true
+const columnId = Number(route.params.id)
+const userId = 12 // TODO: 추후 auth 연동 시, store에서 동적으로 가져올 것
 
-const column = ref({
-  title: '강한 사람이 되는 방법',
-  mentorNickname: '유관순',
-  date: '2025.04.02',
-  likeCount: 10,
-  thumbnailUrl: '',
-  content: `💪 1. 자기 자신을 이해하고 다스리는 힘
+const column = ref(null)
+const isMentor = true // TODO: 로그인 유저와 비교하여 판단
 
-  감정 조절 능력 키우기 : 화나 좌절 같은 감정을 억누르는 게 아니라, 인식하고 조절하는 것이 중요합니다.
-  자존감 기르기 : 남과 비교하지 않고 자신의 가치를 믿는 것.
-  실패를 견디는 힘 : 실패를 두려워하지 말고, 배움의 기회로 받아들이는 자세가 필요합니다.
-
-  ✅ 추천 툴 목록
-
-  1. Postman
-
-  2. Notion`
-})
-
-// 좋아요
 const isLiked = ref(false)
 const toggleLike = () => {
   isLiked.value = !isLiked.value
   column.value.likeCount += isLiked.value ? 1 : -1
 }
 
-// 삭제 모달 상태
-const isDeleteModalVisible = ref(false)
-
-// 삭제 확정 시 실행
-const confirmDelete = () => {
-  // TODO: 삭제 요청 API 호출
-  alert('삭제 요청이 전송되었습니다.')
-  isDeleteModalVisible.value = false
-}
-
-// 이미지
 const fallbackImg = new URL('@/assets/image/product-skeleton.png', import.meta.url).href
 const heartDefault = new URL('@/assets/image/heart-default.png', import.meta.url).href
 const heartActive = new URL('@/assets/image/heart-active.png', import.meta.url).href
 
-// 수정 페이지 이동
+const isDeleteModalVisible = ref(false)
+const confirmDelete = () => {
+  alert('삭제 요청이 전송되었습니다.')
+  isDeleteModalVisible.value = false
+}
+
 const goToEdit = () => {
   router.push(`/columns/edit/${columnId}`)
 }
 
-// 삭제 모달 열기 (추후 구현)
-const handleDelete = () => {
-  isDeleteModalVisible.value = true
-}
+const formattedDate = computed(() => {
+  return column.value?.createdAt
+      ? dayjs(column.value.createdAt).format('YYYY.MM.DD')
+      : ''
+})
+
+onMounted(async () => {
+  try {
+    const res = await getColumnDetail(userId, columnId)
+    column.value = res.data.data
+  } catch (err) {
+    console.error('칼럼 상세 조회 실패', err)
+  }
+})
 </script>
 
 <template>
-  <div class="max-w-[900px] mx-auto py-8 px-4">
-    <!-- '목록으로' 버튼 -->
+  <div class="max-w-[900px] mx-auto py-8 px-4" v-if="column">
+    <!-- 목록으로 -->
     <router-link
         to="/columns"
         class="inline-flex items-center gap-2 text-[var(--newbittext)] text-13px-regular bg-[var(--newbitlightmode)] border border-[var(--newbitdivider)] px-4 py-2 rounded-lg shadow-sm hover:bg-[var(--newbitlightmode-hover)] transition mb-6"
@@ -74,26 +62,20 @@ const handleDelete = () => {
 
     <!-- 썸네일 + 텍스트 -->
     <div class="flex gap-6 mb-6">
-      <!-- 썸네일 -->
       <img
           :src="column.thumbnailUrl || fallbackImg"
           @error="(e) => (e.target.src = fallbackImg)"
-          alt="썸네일"
           class="w-[280px] h-[180px] rounded-lg object-cover bg-gray-100"
+          alt="썸네일"
       />
-
-      <!-- 텍스트 정보 -->
       <div class="flex flex-col justify-between h-[180px] flex-1">
-        <!-- 제목 -->
         <h1 class="text-heading2">{{ column.title }}</h1>
-
-        <!-- 작성자/날짜/좋아요 -->
         <div class="flex flex-col gap-2.5 text-13px-regular text-[var(--newbitgray)]">
           <span>멘토 {{ column.mentorNickname }}</span>
-          <span>작성일 {{ column.date }}</span>
+          <span>작성일 {{ formattedDate }}</span>
           <button
               @click="toggleLike"
-              class="flex items-center gap-1 px-3 py-1 w-fit border border-[var(--newbitdivider)] rounded-md text-13px-regular text-[var(--newbittext)] hover:bg-[var(--newbitlightmode-hover)] transition"
+              class="flex items-center gap-1 px-3 py-1 w-fit border border-[var(--newbitdivider)] rounded-md text-[var(--newbittext)] hover:bg-[var(--newbitlightmode-hover)] transition"
           >
             <img :src="isLiked ? heartActive : heartDefault" class="w-5 h-4.5" alt="하트" />
             <span>{{ column.likeCount }}</span>
@@ -110,7 +92,7 @@ const handleDelete = () => {
     <!-- 멘토 전용 버튼 -->
     <div v-if="isMentor" class="flex justify-end gap-2 mt-6">
       <button @click="goToEdit" class="bg-blue-500 text-white px-4 py-2 rounded">수정</button>
-      <button @click="handleDelete" class="bg-[var(--newbitred)] text-white px-4 py-2 rounded">삭제</button>
+      <button @click="() => isDeleteModalVisible = true" class="bg-[var(--newbitred)] text-white px-4 py-2 rounded">삭제</button>
     </div>
 
     <!-- 삭제 모달 -->
@@ -121,18 +103,14 @@ const handleDelete = () => {
           해당 컨텐츠에 대해 삭제 요청을 보내시겠습니까?
         </p>
         <div class="flex justify-end gap-2">
-          <button @click="isDeleteModalVisible = false"
-                  class="bg-[var(--newbitred)] text-white px-4 py-2 rounded">
-            아니요
-          </button>
-          <button @click="confirmDelete"
-                  class="bg-blue-500 text-white px-4 py-2 rounded">
-            네
-          </button>
+          <button @click="isDeleteModalVisible = false" class="bg-[var(--newbitred)] text-white px-4 py-2 rounded">아니요</button>
+          <button @click="confirmDelete" class="bg-blue-500 text-white px-4 py-2 rounded">네</button>
         </div>
       </div>
     </div>
   </div>
+
+  <div v-else class="text-center py-20 text-[var(--newbitgray)]">칼럼을 불러오는 중입니다...</div>
 </template>
 
 <style scoped></style>

--- a/newbit-frontend/src/features/column/views/ColumnDetailView.vue
+++ b/newbit-frontend/src/features/column/views/ColumnDetailView.vue
@@ -14,7 +14,9 @@ const columnId = Number(route.params.id)
 const userId = authStore.userId || 12;
 // const userId = 12;
 const column = ref(null)
-const isMentor = true // TODO: 로그인 유저와 비교하여 판단
+
+const isMentor = authStore.userRole === 'MENTOR'
+// const isOwner = computed(() => column.value?.mentorId === authStore.mentorId)  // 추후에 적용
 
 const isLiked = ref(false)
 const toggleLike = () => {

--- a/newbit-frontend/src/features/column/views/ColumnDetailView.vue
+++ b/newbit-frontend/src/features/column/views/ColumnDetailView.vue
@@ -16,7 +16,7 @@ const userId = authStore.userId || 12;
 const column = ref(null)
 
 const isMentor = authStore.userRole === 'MENTOR'
-// const isOwner = computed(() => column.value?.mentorId === authStore.mentorId)  // 추후에 적용
+// const isOwner = computed(() => column.value?.mentorId === authStore.mentorId)  // 추후에 적용(작성자 본인만 수정/삭제 버튼 노출하도록 조건 분기)
 
 const isLiked = ref(false)
 const toggleLike = () => {


### PR DESCRIPTION
### 🛰️ Issue
Nbt 426 fe 칼럼 상세 조회 api 연동	

### 🪐 작업 내용
- 칼럼 목록에서 클릭했을 때 상세조회 페이지로 넘어가도록 구현
- 작성자 본인만 수정/삭제 버튼 노출하도록 조건 분기하는 작업 추후 authStore에 mentorId 생성시에 구현 예정
- 현재는 칼럼을 구매한 모든 사용자에게 수정/삭제 버튼 보이고 있음