### PR TITLE
Nbt 449 be 시리즈 목록 조회 dto 생성 및 mentor nickname 필드 수정

### DIFF
--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/ColumnRequestController.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/ColumnRequestController.java
@@ -14,6 +14,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -62,12 +66,13 @@ public class ColumnRequestController {
     }
 
     // 본인 칼럼 요청 조회
-    @Operation(summary = "멘토 본인 칼럼 요청 조회", description = "멘토가 등록, 수정, 삭제 요청한 칼럼 목록을 조회합니다.")
     @GetMapping("/my")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<GetMyColumnRequestResponseDto>> getMyColumnRequests(
-            @AuthenticationPrincipal CustomUser customUser
-            ) {
-        return ApiResponse.success(columnRequestService.getMyColumnRequests(customUser.getUserId()));
+    @Operation(summary = "멘토 본인 칼럼 요청 조회", description = "멘토가 등록, 수정, 삭제 요청한 칼럼 목록을 조회합니다.")
+    public ApiResponse<Page<GetMyColumnRequestResponseDto>> getMyColumnRequests(
+            @AuthenticationPrincipal CustomUser customUser,
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiResponse.success(columnRequestService.getMyColumnRequests(customUser.getUserId(), pageable));
     }
 }

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/SeriesController.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/controller/SeriesController.java
@@ -83,7 +83,7 @@ public class SeriesController {
 
     @GetMapping
     @Operation(summary = "공개된 시리즈 목록 조회", description = "사용자가 볼 수 있는 공개 시리즈 목록을 조회합니다.")
-    public ApiResponse<Page<GetMySeriesListResponseDto>> getPublicSeriesList(
+    public ApiResponse<Page<GetSeriesListResponseDto>> getPublicSeriesList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
@@ -93,7 +93,7 @@ public class SeriesController {
 
     @GetMapping("/public-list/search")
     @Operation(summary = "공개된 시리즈 검색", description = "시리즈 제목 또는 작성자 닉네임으로 공개된 시리즈를 검색합니다.")
-    public ApiResponse<Page<GetMySeriesListResponseDto>> searchPublicSeriesList(
+    public ApiResponse<Page<GetSeriesListResponseDto>> searchPublicSeriesList(
             @ModelAttribute SearchCondition condition,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/domain/Series.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/domain/Series.java
@@ -41,6 +41,7 @@ public class Series {
     private Long mentorId;
 
     @jakarta.persistence.Column(nullable = false)
+    @Transient
     private String mentorNickname;
 
     @OneToMany(mappedBy = "series", cascade = CascadeType.PERSIST)

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetSeriesListResponseDto.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/dto/response/GetSeriesListResponseDto.java
@@ -1,0 +1,38 @@
+package com.newbit.newbitfeatureservice.column.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "공개 시리즈 리스트 조회 응답")
+public class GetSeriesListResponseDto {
+
+    @Schema(description = "시리즈 ID", example = "1")
+    private Long seriesId;
+
+    @Schema(description = "시리즈 제목", example = "이직 준비 A to Z")
+    private String title;
+
+    @Schema(description = "시리즈 설명", example = "이직 준비 꿀팁 모음")
+    private String description;
+
+    @Schema(description = "썸네일 URL", example = "https://example.com/image.jpg")
+    private String thumbnailUrl;
+
+    @Schema(description = "멘토 ID", example = "5")
+    private Long mentorId;
+
+    @Schema(description = "멘토 닉네임", example = "개발자도토리")
+    private String mentorNickname;
+
+    @Schema(description = "작성일시", example = "2025-07-02T09:00:00")
+    private LocalDateTime createdAt;
+
+    public void setMentorNickname(String nickname) {
+        this.mentorNickname = nickname;
+    }
+}

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRequestRepository.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/ColumnRequestRepository.java
@@ -1,11 +1,13 @@
 package com.newbit.newbitfeatureservice.column.repository;
 
 import com.newbit.newbitfeatureservice.column.domain.ColumnRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ColumnRequestRepository extends JpaRepository<ColumnRequest, Long> {
 
-    List<ColumnRequest> findAllByColumn_MentorIdOrderByCreatedAtDesc(Long mentorId);
+    Page<ColumnRequest> findAllByColumn_MentorIdOrderByCreatedAtDesc(Long mentorId, Pageable pageable);
 }

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/SeriesRepository.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/repository/SeriesRepository.java
@@ -27,8 +27,7 @@ public interface SeriesRepository extends JpaRepository<Series, Long> {
     FROM Series s
     WHERE (
         :keyword IS NULL OR
-        LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-        LOWER(s.mentorNickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
     )
     AND EXISTS (
         SELECT 1 FROM Column c WHERE c.series.seriesId = s.seriesId

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/service/ColumnRequestService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/service/ColumnRequestService.java
@@ -20,6 +20,8 @@ import com.newbit.newbitfeatureservice.common.exception.BusinessException;
 import com.newbit.newbitfeatureservice.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -102,14 +104,12 @@ public class ColumnRequestService {
                 .build();
     }
 
-    public List<GetMyColumnRequestResponseDto> getMyColumnRequests(Long userId) {
+    public Page<GetMyColumnRequestResponseDto> getMyColumnRequests(Long userId, Pageable pageable) {
         Long mentorId = mentorFeignClient.getMentorIdByUserId(userId).getData();
 
-        List<ColumnRequest> requests = columnRequestRepository.findAllByColumn_MentorIdOrderByCreatedAtDesc(mentorId);
+        Page<ColumnRequest> page = columnRequestRepository.findAllByColumn_MentorIdOrderByCreatedAtDesc(mentorId, pageable);
 
-        return requests.stream()
-                .map(columnMapper::toMyColumnRequestResponseDto)
-                .toList();
+        return page.map(columnMapper::toMyColumnRequestResponseDto);
     }
 
     public Integer getColumnPriceById(Long columnId) {

--- a/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/service/SeriesService.java
+++ b/newbit-feature-service/src/main/java/com/newbit/newbitfeatureservice/column/service/SeriesService.java
@@ -1,10 +1,15 @@
 package com.newbit.newbitfeatureservice.column.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.newbit.newbitfeatureservice.client.user.MentorFeignClient;
+import com.newbit.newbitfeatureservice.client.user.UserFeignClient;
 import com.newbit.newbitfeatureservice.column.dto.request.SearchCondition;
+import com.newbit.newbitfeatureservice.column.dto.response.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,11 +19,6 @@ import com.newbit.newbitfeatureservice.column.domain.Column;
 import com.newbit.newbitfeatureservice.column.domain.Series;
 import com.newbit.newbitfeatureservice.column.dto.request.CreateSeriesRequestDto;
 import com.newbit.newbitfeatureservice.column.dto.request.UpdateSeriesRequestDto;
-import com.newbit.newbitfeatureservice.column.dto.response.CreateSeriesResponseDto;
-import com.newbit.newbitfeatureservice.column.dto.response.GetMySeriesListResponseDto;
-import com.newbit.newbitfeatureservice.column.dto.response.GetSeriesColumnsResponseDto;
-import com.newbit.newbitfeatureservice.column.dto.response.GetSeriesDetailResponseDto;
-import com.newbit.newbitfeatureservice.column.dto.response.UpdateSeriesResponseDto;
 import com.newbit.newbitfeatureservice.column.mapper.SeriesMapper;
 import com.newbit.newbitfeatureservice.column.repository.ColumnRepository;
 import com.newbit.newbitfeatureservice.column.repository.SeriesRepository;
@@ -27,6 +27,7 @@ import com.newbit.newbitfeatureservice.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeriesService {
@@ -35,6 +36,7 @@ public class SeriesService {
     private final ColumnRepository columnRepository;
     private final MentorFeignClient mentorFeignClient;
     private final SeriesMapper seriesMapper;
+    private final UserFeignClient userFeignClient;
 
     @Transactional
     public CreateSeriesResponseDto createSeries(CreateSeriesRequestDto dto, Long userId) {
@@ -172,13 +174,46 @@ public class SeriesService {
     }
 
     @Transactional(readOnly = true)
-    public Page<GetMySeriesListResponseDto> getMySeriesList(Long userId, int page, int size) {
-        Long mentorId = mentorFeignClient.getMentorIdByUserId(userId).getData();
+    public Page<GetSeriesListResponseDto> getPublicSeriesList(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
+        Page<Series> allSeries = seriesRepository.findAllByColumnsIsNotEmpty(pageable);
 
-        Page<Series> seriesPage = seriesRepository.findAllByMentorIdOrderByCreatedAtDesc(mentorId, pageable);
-        return seriesPage
-                .map(seriesMapper::toMySeriesListDto);
+        List<GetSeriesListResponseDto> content = new ArrayList<>();
+
+        for (Series series : allSeries.getContent()) {
+            try {
+                Long mentorId = series.getMentorId();
+
+                // 1단계: mentorId -> userId
+                var mentorResponse = mentorFeignClient.getUserIdByMentorId(mentorId);
+                if (mentorResponse.getData() == null) continue;
+
+                Long userId = mentorResponse.getData();
+
+                // 2단계: userId -> nickname
+                var nickname = userFeignClient.getNicknameByUserId(userId).getData();
+                if (nickname == null) continue;
+
+                // DTO 생성 + 닉네임 주입
+                GetSeriesListResponseDto dto = GetSeriesListResponseDto.builder()
+                        .seriesId(series.getSeriesId())
+                        .title(series.getTitle())
+                        .description(series.getDescription())
+                        .thumbnailUrl(series.getThumbnailUrl())
+                        .mentorId(mentorId)
+                        .createdAt(series.getCreatedAt())
+                        .build();
+
+                dto.setMentorNickname(nickname);
+
+                content.add(dto);
+
+            } catch (Exception e) {
+                log.warn("Failed to fetch mentor nickname for mentorId={}", series.getMentorId(), e);
+            }
+        }
+
+        return new PageImpl<>(content, pageable, allSeries.getTotalElements());
     }
 
     @Transactional(readOnly = true)
@@ -197,20 +232,54 @@ public class SeriesService {
                 .map(seriesMapper::toSeriesColumnDto);
     }
 
-    public Page<GetMySeriesListResponseDto> getPublicSeriesList(int page, int size) {
+    @Transactional(readOnly = true)
+    public Page<GetMySeriesListResponseDto> getMySeriesList(Long userId, int page, int size) {
+        Long mentorId = mentorFeignClient.getMentorIdByUserId(userId).getData();
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<Series> allSeries = seriesRepository.findAllByColumnsIsNotEmpty(pageable);
-
-        return allSeries.map(seriesMapper::toMySeriesListDto);
+        Page<Series> seriesPage = seriesRepository.findAllByMentorIdOrderByCreatedAtDesc(mentorId, pageable);
+        return seriesPage.map(seriesMapper::toMySeriesListDto);
     }
 
     // 시리즈 검색 기능
-    public Page<GetMySeriesListResponseDto> searchPublicSeriesList(SearchCondition condition, int page, int size) {
+    @Transactional(readOnly = true)
+    public Page<GetSeriesListResponseDto> searchPublicSeriesList(SearchCondition condition, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Series> seriesPage = seriesRepository.searchSeriesByKeyword(condition.getKeyword(), pageable);
-        return seriesPage.map(seriesMapper::toMySeriesListDto);
+
+        List<GetSeriesListResponseDto> content = new ArrayList<>();
+
+        for (Series series : seriesPage.getContent()) {
+            try {
+                Long mentorId = series.getMentorId();
+                var mentorResponse = mentorFeignClient.getUserIdByMentorId(mentorId);
+                if (mentorResponse.getData() == null) continue;
+
+                Long userId = mentorResponse.getData();
+                var nickname = userFeignClient.getNicknameByUserId(userId).getData();
+                if (nickname == null) continue;
+
+                GetSeriesListResponseDto dto = GetSeriesListResponseDto.builder()
+                        .seriesId(series.getSeriesId())
+                        .title(series.getTitle())
+                        .description(series.getDescription())
+                        .thumbnailUrl(series.getThumbnailUrl())
+                        .mentorId(series.getMentorId())
+                        .createdAt(series.getCreatedAt())
+                        .build();
+
+                dto.setMentorNickname(nickname);
+                content.add(dto);
+
+            } catch (Exception e) {
+                log.warn("멘토 닉네임 조회 실패: mentorId={}, seriesId={}, title={}",
+                        series.getMentorId(), series.getSeriesId(), series.getTitle(), e);
+            }
+        }
+
+        return new PageImpl<>(content, pageable, seriesPage.getTotalElements());
     }
+
 
     @Transactional(readOnly = true)
     public int getColumnCountBySeriesId(Long seriesId) {

--- a/newbit-frontend/src/api/column.js
+++ b/newbit-frontend/src/api/column.js
@@ -36,8 +36,8 @@ export const deleteColumnRequest = (columnId, data) =>
     api.post(`feature/columns/requests/${columnId}/delete`, data)
 
 // 본인 칼럼 요청 목록 조회
-export const getMyColumnRequests = () =>
-    api.get('feature/columns/requests/my')
+export const getMyColumnRequests = (params) =>
+    api.get('feature/columns/requests/my', { params })
 
 
 /* --- 칼럼 관리자 승인/거절 --- */

--- a/newbit-frontend/src/features/mypage/views/ColumnRequestHistoryView.vue
+++ b/newbit-frontend/src/features/mypage/views/ColumnRequestHistoryView.vue
@@ -1,14 +1,14 @@
 <template>
-  <section class="px-6 py-8">
+  <section class="w-full max-w-[900px] mx-auto px-6 py-8">
     <h2 class="text-heading2 mb-8">칼럼 요청 내역</h2>
 
     <div v-if="columnRequests.length > 0" class="flex flex-col gap-6">
       <div
           v-for="item in columnRequests"
           :key="item.id"
-          class="flex justify-between items-start p-5 border border-[var(--newbitdivider)] rounded-lg shadow-sm"
+          class="flex justify-between items-start p-5 border border-[var(--newbitdivider)] rounded-lg shadow-sm bg-white"
       >
-        <!-- 텍스트 -->
+        <!-- 왼쪽 텍스트 -->
         <div class="flex flex-col justify-between flex-1 pr-4">
           <h3 class="text-heading3 mb-4">{{ item.title }}</h3>
 
@@ -30,6 +30,7 @@
           </p>
         </div>
 
+        <!-- 썸네일 -->
         <div class="w-[180px] h-[120px]">
           <img
               :src="item.thumbnailUrl || fallbackImg"

--- a/newbit-frontend/src/features/mypage/views/ColumnRequestHistoryView.vue
+++ b/newbit-frontend/src/features/mypage/views/ColumnRequestHistoryView.vue
@@ -48,13 +48,12 @@
       </div>
 
       <!-- 페이지네이션 (임시) -->
-      <div class="flex justify-center mt-10 gap-2 text-13px-regular text-[var(--newbitgray)]">
-        <span class="cursor-pointer">← Previous</span>
-        <span class="font-bold text-[var(--newbitnormal)]">1</span>
-        <span class="cursor-pointer">2</span>
-        <span class="cursor-pointer">3</span>
-        <span class="cursor-pointer">Next →</span>
-      </div>
+      <PagingBar
+          :currentPage="currentPage"
+          :totalPage="totalPage"
+          @page-change="handlePageChange"
+      />
+
     </div>
   </div>
 </template>
@@ -63,9 +62,11 @@
 import { ref, onMounted } from 'vue'
 import { getMyColumnRequests } from '@/api/column'
 import { useToast } from 'vue-toastification'
+import PagingBar from "@/components/common/PagingBar.vue";
 
 const toast = useToast()
-
+const currentPage = ref(1)
+const totalPage = ref(1)
 const columnRequests = ref([])
 
 const diamondIcon = new URL('@/assets/image/diamond-icon.png', import.meta.url).href
@@ -83,6 +84,11 @@ const requestTypeToKorean = (type) => {
   if (type === 'UPDATE') return '수정'
   if (type === 'DELETE') return '삭제'
   return ''
+}
+
+const handlePageChange = (page) => {
+  currentPage.value = page
+  fetchColumns()
 }
 
 onMounted(async () => {

--- a/newbit-frontend/src/features/mypage/views/ColumnRequestHistoryView.vue
+++ b/newbit-frontend/src/features/mypage/views/ColumnRequestHistoryView.vue
@@ -1,72 +1,69 @@
 <template>
-  <div class="flex">
-    <!-- 메인 콘텐츠 -->
-    <div class="flex-1 px-10 py-8">
-      <h2 class="text-heading2 mb-8">칼럼 요청 내역</h2>
+  <section class="px-6 py-8">
+    <h2 class="text-heading2 mb-8">칼럼 요청 내역</h2>
 
-      <div class="flex flex-col gap-8">
-        <div
-            v-for="item in columnRequests"
-            :key="item.id"
-            class="flex justify-between border-b pb-3"
-        >
-          <!-- 왼쪽: 텍스트 -->
-          <div class="flex flex-col gap-2 flex-1">
-            <!-- 제목 -->
-            <h3 class="text-16px-bold text-[var(--newbittext)] mb-8">
-              {{ item.title }}
-            </h3>
+    <div v-if="columnRequests.length > 0" class="flex flex-col gap-6">
+      <div
+          v-for="item in columnRequests"
+          :key="item.id"
+          class="flex justify-between items-start p-5 border border-[var(--newbitdivider)] rounded-lg shadow-sm"
+      >
+        <!-- 텍스트 -->
+        <div class="flex flex-col justify-between flex-1 pr-4">
+          <h3 class="text-heading3 mb-4">{{ item.title }}</h3>
 
-            <!-- 메타 정보 -->
-            <div class="flex items-center gap-4 text-13px-regular text-[var(--newbitgray)]">
-              <div class="flex items-center gap-1">
-                <img :src="diamondIcon" alt="다이아" class="w-4 h-4" />
-                <span>{{ item.diamondCount }} </span>
-              </div>
-              <span>|</span>
-              <span>요청 일시 {{ item.date }}</span>
-              <span>|</span>
-              <span>{{ item.type }}</span>
-              <span>|</span>
-              <span>상태: <span :class="statusColor(item.status)">{{ item.status }}</span></span>
+          <div class="flex items-center gap-4 text-13px-regular text-[var(--newbitgray)] mb-2">
+            <div class="flex items-center gap-1">
+              <img :src="diamondIcon" alt="다이아" class="w-4 h-4" />
+              <span>{{ item.diamondCount }}</span>
             </div>
-
-            <!-- 반려 사유 -->
-            <p v-if="item.status === '반려'" class="text-13px-regular text-[var(--newbitgray)]">
-              반려 사유 : {{ item.rejectedReason }}
-            </p>
+            <span>|</span>
+            <span>요청 일시 {{ item.date }}</span>
+            <span>|</span>
+            <span>{{ item.type }}</span>
+            <span>|</span>
+            <span>상태: <span :class="statusColor(item.status)">{{ item.status }}</span></span>
           </div>
 
-          <!-- 썸네일 -->
+          <p v-if="item.status === '반려'" class="text-13px-regular text-[var(--newbitgray)]">
+            반려 사유 : {{ item.rejectedReason }}
+          </p>
+        </div>
+
+        <div class="w-[180px] h-[120px]">
           <img
               :src="item.thumbnailUrl || fallbackImg"
               @error="(e) => (e.target.src = fallbackImg)"
               alt="썸네일"
-              class="w-[160px] h-[100px] object-cover rounded-md"
+              class="w-full h-full object-cover rounded-lg"
           />
         </div>
       </div>
-
-      <!-- 페이지네이션 (임시) -->
-      <PagingBar
-          :currentPage="currentPage"
-          :totalPage="totalPage"
-          @page-change="handlePageChange"
-      />
-
     </div>
-  </div>
-</template>
 
+    <div v-else class="text-center text-[var(--newbitgray)] py-20">
+      칼럼 요청 내역이 없습니다.
+    </div>
+
+    <!-- 페이지네이션 -->
+    <PagingBar
+        class="mt-10"
+        :currentPage="currentPage"
+        :totalPages="totalPage"
+        @page-change="handlePageChange"
+    />
+  </section>
+</template>
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getMyColumnRequests } from '@/api/column'
 import { useToast } from 'vue-toastification'
-import PagingBar from "@/components/common/PagingBar.vue";
+import { getMyColumnRequests } from '@/api/column'
+import PagingBar from '@/components/common/PagingBar.vue'
 
 const toast = useToast()
 const currentPage = ref(1)
 const totalPage = ref(1)
+const pageSize = 5
 const columnRequests = ref([])
 
 const diamondIcon = new URL('@/assets/image/diamond-icon.png', import.meta.url).href
@@ -78,7 +75,6 @@ const statusColor = (status) => {
   return 'text-[var(--newbitgray)]'
 }
 
-// 요청 타입 한글 변환
 const requestTypeToKorean = (type) => {
   if (type === 'CREATE') return '등록'
   if (type === 'UPDATE') return '수정'
@@ -86,15 +82,17 @@ const requestTypeToKorean = (type) => {
   return ''
 }
 
-const handlePageChange = (page) => {
-  currentPage.value = page
-  fetchColumns()
-}
-
-onMounted(async () => {
+const fetchColumns = async () => {
   try {
-    const res = await getMyColumnRequests()
-    columnRequests.value = res.data.data.map((item) => ({
+    const res = await getMyColumnRequests({
+      page: currentPage.value - 1,
+      size: pageSize
+    })
+
+    const { content, totalPages } = res.data.data
+    totalPage.value = totalPages
+
+    columnRequests.value = content.map((item) => ({
       id: item.columnRequestId,
       title: item.title,
       diamondCount: item.price || 0,
@@ -107,7 +105,14 @@ onMounted(async () => {
   } catch (e) {
     toast.error('칼럼 요청 목록을 불러오지 못했어요.')
   }
+}
+
+const handlePageChange = (page) => {
+  currentPage.value = page
+  fetchColumns()
+}
+
+onMounted(() => {
+  fetchColumns()
 })
 </script>
-<style scoped>
-</style>


### PR DESCRIPTION
### 🛰️ Issue
Nbt 449 be 시리즈 목록 조회 dto 생성 및 mentor nickname 필드 수정	

### 🪐 작업 내용
- mentorNickname @Transient 처리
- 시리즈 목록 (공개 조회) DTO 생성
- 시리즈 공개 조회와 내 시리즈 조회 다시 매핑, 포스트맨 에러 해결
- 칼럼 요청 내역 목록 조회 페이지 연동(에러 해결)
- 칼럼 요청 내역 페이징 처리(프론트, 백엔드)
- 칼럼 요청 내역 UI 정렬
